### PR TITLE
ci: restore build after tool and refactor updates

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -76,5 +76,5 @@ jobs:
       - run: uv run ${{ github.event.repository.name }} output-prompt
       - run: uv run ${{ github.event.repository.name }} output-exclusions
       - run: uv run ${{ github.event.repository.name }} dump-prompts
-      - run: uv run ${{ github.event.repository.name }} install-pre-commit
+      - run: uv run ${{ github.event.repository.name }} install
       - run: just test

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This is the simplest way to add project-specific instructions without duplicatin
 To automatically generate commit messages during git commits:
 
 ```
-aiautocommit install-pre-commit
+aiautocommit install
 ```
 
 [Learn more about git hooks here.](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -123,7 +123,9 @@ EXCLUSIONS_FILE = "excluded_files.txt"
 COMMIT_SUFFIX_FILE = "commit_suffix.txt"
 
 # https://ai.pydantic.dev/models/overview
-MODEL_NAME = os.environ.get("AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview")
+MODEL_NAME = os.environ.get(
+    "AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview"
+)
 
 COMMIT_PROMPT = ""
 EXCLUDED_FILES = []
@@ -641,6 +643,7 @@ def install(overwrite):
             "pre-commit hook already exists. Here's the contents we would have written:\n"
         )
         click.echo(pre_commit_script.read_text())
+
 
 @main.command()
 def uninstall():

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -576,7 +576,7 @@ def commit(print_message, output_file, config_dir):
                     )
                     click.get_current_context().exit(1)
             else:
-                diff = staged_diff
+                diff = get_diff()
                 if not diff:
                     commit_message = "style: whitespace change" + COMMIT_SUFFIX
                 else:
@@ -641,7 +641,6 @@ def install(overwrite):
             "pre-commit hook already exists. Here's the contents we would have written:\n"
         )
         click.echo(pre_commit_script.read_text())
-
 
 @main.command()
 def uninstall():

--- a/aiautocommit/internet.py
+++ b/aiautocommit/internet.py
@@ -20,5 +20,5 @@ def is_internet_connected():
         with socket.socket(socket.AF_INET) as s:
             s.connect(("google.com", 80))
             return True
-    except socket.error:
+    except OSError:
         return False

--- a/aiautocommit/log.py
+++ b/aiautocommit/log.py
@@ -1,9 +1,9 @@
-import os
 import logging
+import os
 import sys
 
-from structlog_config import configure_logger
 import structlog
+from structlog_config import configure_logger
 
 
 def setup_logging():

--- a/aiautocommit/pull_request.py
+++ b/aiautocommit/pull_request.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import time
 from pathlib import Path
-from typing import Optional
 
 from .log import log
 from .utils import is_default_branch, run_command
@@ -14,7 +13,7 @@ PR_CONTENT_CACHE_TTL = 7200  # 2 hours
 NEGATIVE_CACHE_TTL = 3600  # 1 hour
 
 
-def get_git_dir() -> Optional[Path]:
+def get_git_dir() -> Path | None:
     try:
         return Path(
             run_command(["git", "rev-parse", "--git-dir"], check=True).stdout.strip()
@@ -23,7 +22,7 @@ def get_git_dir() -> Optional[Path]:
         return None
 
 
-def get_pr_number_from_git_config(branch: str) -> Optional[str]:
+def get_pr_number_from_git_config(branch: str) -> str | None:
     """Check git config for a stored PR number."""
     try:
         result = run_command(
@@ -52,7 +51,7 @@ def get_pr_number_from_git_config(branch: str) -> Optional[str]:
     return None
 
 
-def get_pull_request_context(branch: str) -> Optional[str]:
+def get_pull_request_context(branch: str) -> str | None:
     """
     Fetch the pull request context for the given branch.
     Requires AIAUTOCOMMIT_INCLUDE_PR_CONTEXT environment variable to be truthy.

--- a/aiautocommit/timing.py
+++ b/aiautocommit/timing.py
@@ -30,10 +30,10 @@ class log_execution_time(ContextDecorator):
 
     # NOTE exit is still called even if an exception is raised
     def __exit__(self, _type, _value, _traceback):
-        elapsed = perf_counter() - self.time
+        elapsed = round(perf_counter() - self.time, 4)
 
         log.debug(
-            f"{self.msg} took {elapsed:.3f} seconds",
+            self.msg,
             execution_time=elapsed,
             function_name=self.msg,
         )

--- a/aiautocommit/timing.py
+++ b/aiautocommit/timing.py
@@ -17,7 +17,7 @@ class log_execution_time(ContextDecorator):
         # Your code here...
     """
 
-    def __init__(self, msg=None):
+    def __init__(self, msg: str):
         """
         :param msg: message to log, normally a function name
         """
@@ -39,7 +39,7 @@ class log_execution_time(ContextDecorator):
         )
 
 
-def log_time(msg=None):
+def log_time(msg: str | None = None):
     """
     Decorator that debug logs the execution time of a function.
 

--- a/aiautocommit/timing.py
+++ b/aiautocommit/timing.py
@@ -1,0 +1,65 @@
+import functools
+from contextlib import ContextDecorator
+from time import perf_counter
+
+from .log import log
+
+
+class log_execution_time(ContextDecorator):
+    """
+    Context manager that logs the execution time of a block of code.
+
+    https://stackoverflow.com/questions/33987060/python-context-manager-that-measures-time
+
+    Usage:
+
+    with log_execution_time('description'):
+        # Your code here...
+    """
+
+    def __init__(self, msg=None):
+        """
+        :param msg: message to log, normally a function name
+        """
+
+        self.msg = msg
+
+    def __enter__(self):
+        self.time = perf_counter()
+        return self
+
+    # NOTE exit is still called even if an exception is raised
+    def __exit__(self, _type, _value, _traceback):
+        elapsed = perf_counter() - self.time
+
+        log.debug(
+            f"{self.msg} took {elapsed:.3f} seconds",
+            execution_time=elapsed,
+            function_name=self.msg,
+        )
+
+
+def log_time(msg=None):
+    """
+    Decorator that debug logs the execution time of a function.
+
+    >>> @log_time()
+    >>> def my_function():
+    >>>    pass
+
+    >>> @log_time('My custom message')
+    >>> def my_function():
+    >>>    pass
+    """
+
+    def decorator(func):
+        function_name = func.__name__
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with log_execution_time(msg or function_name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/aiautocommit/utils.py
+++ b/aiautocommit/utils.py
@@ -1,6 +1,5 @@
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Union
 
 from .log import log
 from .timing import log_execution_time
@@ -38,13 +37,13 @@ def safe_git_diff_cmd() -> list[str]:
 
 
 def run_command(
-    args: List[str],
+    args: list[str],
     check: bool = False,
     capture_output: bool = True,
     text: bool = True,
-    timeout: Optional[float] = None,
-    env: Optional[dict[str, str]] = None,
-    cwd: Optional[Union[str, Path]] = None,
+    timeout: float | None = None,
+    env: dict[str, str] | None = None,
+    cwd: str | Path | None = None,
 ) -> subprocess.CompletedProcess:
     """
     Run a shell command using subprocess.run with logging.
@@ -79,7 +78,7 @@ def run_command(
             raise
 
 
-def get_current_branch() -> Optional[str]:
+def get_current_branch() -> str | None:
     """Get the name of the current git branch."""
     try:
         result = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True)

--- a/mise.lock
+++ b/mise.lock
@@ -4,12 +4,29 @@
 version = "2.37.1"
 backend = "asdf:direnv"
 
-[[tools.just]]
-version = "1.48.1"
-backend = "ubi:casey/just"
+[[tools."github:casey/just"]]
+version = "1.56.0"
+backend = "github:casey/just"
 
-[tools.just."platforms.macos-arm64-just"]
-checksum = "blake3:0deb700777be34ea81a1f743b4c014c32241d554a040296a0914604cea41ecf6"
+[tools."github:casey/just"."platforms.linux-arm64"]
+checksum = "sha256:c8c1d656e9f47569ec1ae2bf8779af2621cdeea6bbbba3b0cacd64f951d25e2b"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074960"
+
+[tools."github:casey/just"."platforms.linux-x64"]
+checksum = "sha256:fa2a8ec1015d9df5330941ade12437488fc40d33f9c9f8cd4eb70a26de11b639"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074624"
+
+[tools."github:casey/just"."platforms.macos-arm64"]
+checksum = "sha256:f35798d4bcdc4db020eef7d2853ad98bbfb97a4d29ee695ba042f18e7fedcc11"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074635"
+
+[tools."github:casey/just"."platforms.macos-x64"]
+checksum = "sha256:09b35ff6d17023ffae37ce408d1a78a976d9e001cae54b88e238f7f40db9b783"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074650"
 
 [[tools.python]]
 version = "3.14.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ dependencies = [
     "structlog-config>=0.6.0",
     "backoff>=2.2.1",
     "click>=8.1.7",
-    "pydantic-ai-slim[anthropic,google,openai]>=1.97.0",
+    "pydantic-ai-slim[anthropic,google,openai]>=2.19.0",
 ]
 authors = [{ name = "Michael Bianco", email = "mike@mikebian.co" }]
 urls = { "Repository" = "https://github.com/iloveitaly/aiautocommit" }
 
 [project.optional-dependencies]
 all-providers = [
-    "pydantic-ai>=1.97.0",
+    "pydantic-ai>=2.19.0",
 ]
 
 # additional packaging information: https://packaging.python.org/en/latest/specifications/core-metadata/#license

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 from tests.utils import GitTestMixin
@@ -19,6 +21,12 @@ def clean_env():
     # Restore environment
     os.environ.clear()
     os.environ.update(old_env)
+
+
+@pytest.fixture(autouse=True)
+def internet_connection_available():
+    with patch("aiautocommit.wait_for_internet_connection"):
+        yield
 
 
 @pytest.fixture

--- a/tests/test_ai_key.py
+++ b/tests/test_ai_key.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+
 from aiautocommit import update_env_variables
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from aiautocommit import check_lock_files, is_reversion, main, update_env_variables
+
 from tests.utils import GitTestMixin
 
 
@@ -195,8 +196,9 @@ def test_configure_prompts_with_examples(runner, git_repo):
 
 
 def test_complete_503_graceful_fallback():
-    from aiautocommit import complete
     from pydantic_ai.exceptions import ModelHTTPError
+
+    from aiautocommit import complete
 
     with patch("aiautocommit.Agent") as mock_agent_class:
         mock_agent = mock_agent_class.return_value

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -248,8 +248,8 @@ def test_generate_commit_message_with_suffix():
 
 
 def test_install_pre_commit_exists(runner, git_repo):
-    runner.invoke(main, ["install-pre-commit"])
-    result = runner.invoke(main, ["install-pre-commit"])
+    runner.invoke(main, ["install"])
+    result = runner.invoke(main, ["install"])
     assert "pre-commit hook already exists" in result.output
 
 

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -1,19 +1,22 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
+
 from aiautocommit import (
-    main,
-    is_reversion,
-    check_lock_files,
     LOCK_FILE_MESSAGES,
-    update_env_variables,
+    check_lock_files,
     configure_prompts,
+    get_diff_size,
+    is_reversion,
+    main,
+    sort_git_diff,
+    update_env_variables,
 )
 from aiautocommit.internet import wait_for_internet_connection
 from aiautocommit.utils import run_command
-from aiautocommit import sort_git_diff, get_diff_size
 
 
 def test_is_reversion_revert_head(git_repo):
@@ -93,7 +96,7 @@ def test_check_lock_files_not_mise_lock(git_repo):
 
 
 def test_get_diff_exclusion_glob(git_repo):
-    from aiautocommit import get_diff, configure_prompts
+    from aiautocommit import configure_prompts, get_diff
 
     # Setup a custom config with the glob pattern
     config_dir = Path("custom_config")
@@ -426,7 +429,7 @@ def test_main_default_invoke(runner):
     mock_ctx = MagicMock()
     mock_ctx.invoked_subcommand = None
     with patch("click.get_current_context", return_value=mock_ctx):
-        from aiautocommit import main, commit
+        from aiautocommit import commit, main
 
         main.callback()
         mock_ctx.invoke.assert_called_with(commit)

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,7 +1,9 @@
-from unittest.mock import patch, MagicMock
-from aiautocommit import complete
-from pydantic_ai.models.google import GoogleModel
+from unittest.mock import MagicMock, patch
+
 from google.genai.types import ThinkingLevel
+from pydantic_ai.models.google import GoogleModel
+
+from aiautocommit import complete
 
 
 @patch("aiautocommit.Agent")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,11 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 from click.testing import CliRunner
+
 from aiautocommit import main
+
 from tests.utils import GitTestMixin
 
 

--- a/tests/test_internet.py
+++ b/tests/test_internet.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
-import socket
+
 import pytest
+
 from aiautocommit.internet import is_internet_connected, wait_for_internet_connection
 
 
@@ -17,7 +18,7 @@ def test_is_internet_connected_success(mock_socket):
 def test_is_internet_connected_failure(mock_socket):
     # Mock connection failure
     instance = mock_socket.return_value.__enter__.return_value
-    instance.connect.side_effect = socket.error("no connection")
+    instance.connect.side_effect = OSError("no connection")
 
     assert is_internet_connected() is False
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from aiautocommit.timing import log_execution_time
+
+
+def test_logs_rounded_execution_time_without_timing_in_message():
+    with (
+        patch("aiautocommit.timing.perf_counter", side_effect=[1.0, 1.123456]),
+        patch("aiautocommit.timing.log.debug") as mock_debug,
+    ):
+        with log_execution_time("example"):
+            pass
+
+    mock_debug.assert_called_once_with(
+        "example",
+        execution_time=0.1235,
+        function_name="example",
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import subprocess
+
 import pytest
+
 from aiautocommit.utils import get_current_branch, run_command
 
 

--- a/tests/test_version_unknown.py
+++ b/tests/test_version_unknown.py
@@ -1,8 +1,8 @@
-import sys
 import os
-from unittest.mock import patch
+import sys
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from unittest.mock import patch
 
 
 def test_version_unknown():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
-import subprocess
 import os
+import subprocess
 
 
 class GitTestMixin:

--- a/uv.lock
+++ b/uv.lock
@@ -40,8 +40,8 @@ dev = [
 requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "click", specifier = ">=8.1.7" },
-    { name = "pydantic-ai", marker = "extra == 'all-providers'", specifier = ">=1.97.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=1.97.0" },
+    { name = "pydantic-ai", marker = "extra == 'all-providers'", specifier = ">=2.19.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=2.19.0" },
     { name = "structlog-config", specifier = ">=0.6.0" },
 ]
 provides-extras = ["all-providers"]
@@ -1405,19 +1405,19 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "2.12.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "retries", "web"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/0d/9d4abf5204bf9da1d9daa2d21b9b95512327d9f9ba30507054df02e198a2/pydantic_ai-2.12.0.tar.gz", hash = "sha256:3fc31dd50fb3545082c5b3907e4acd10a56564e33aecd14b646a6b92ff61c86a", size = 18552, upload-time = "2026-07-17T02:51:12.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/e9/d7e65cc8a30facdf25ab30d3392bbb12e659093c627774ef99c6772a44e2/pydantic_ai-2.19.0.tar.gz", hash = "sha256:0741c0c31bed3e7b39ec30ac916be46b3095249fd4dce265afdffaacf885fe4a", size = 18863, upload-time = "2026-07-28T03:40:49.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/68/46bee40635a533684a1b3bab6704f9c49667724c2ab3063a3e31d2fc69a8/pydantic_ai-2.12.0-py3-none-any.whl", hash = "sha256:704f01007917bdb16812bfbcde50cda33bb82f2c0f1064775fe1782d89514924", size = 7729, upload-time = "2026-07-17T02:51:04.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/41/f4a907a6cab70928036ff9b56d8b3d9c52f49d50660c7b88f69213b09e6b/pydantic_ai-2.19.0-py3-none-any.whl", hash = "sha256:a45d9698b9ad57d87d8867de1d9116fca4b7f5bf45049bdee505760f62dabc15", size = 7746, upload-time = "2026-07-28T03:40:40.622Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.12.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -1428,9 +1428,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/4b/66b18a386e5776963c7cc209e52db38d690fb001d20bc866fb7fe9dd18e4/pydantic_ai_slim-2.12.0.tar.gz", hash = "sha256:ff09077eda4a60ef84853d880d451f3c1ce809f7a15b140c5c28fc1e5d9b2e48", size = 829663, upload-time = "2026-07-17T02:51:14.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/83/89abdc0a63eec1ab12c84ffa80c4e9572f8a58243a62769f91eda144c885/pydantic_ai_slim-2.19.0.tar.gz", hash = "sha256:79d8f03c00dcf527a8fcf9de00f0d47f39712597057c4a539fa841e06054b4e8", size = 904694, upload-time = "2026-07-28T03:40:51.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/c0/a84ca4337acfef3389276a1cc2044ac37b02ddf713f1dd4243f8b8e5b93f/pydantic_ai_slim-2.12.0-py3-none-any.whl", hash = "sha256:192b0eac8458f101ae44fe25e0afd4465586392ac5ccd0636061e6299beea8c8", size = 1008373, upload-time = "2026-07-17T02:51:07.007Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/36/72d9d0c40cc9ac44b2bc359eb3c611d445077a988661ff3162ea9f96de1a/pydantic_ai_slim-2.19.0-py3-none-any.whl", hash = "sha256:5663f4e2fa0b0a63eab355ccf297bae8682bfcbb0efd7c1dd6e334860d794687", size = 1094129, upload-time = "2026-07-28T03:40:43.496Z" },
 ]
 
 [package.optional-dependencies]
@@ -1546,7 +1546,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "2.12.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1556,14 +1556,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e0/bf2d331f01e1f93785b70448a3d281916d8913bfc1db17205219b234b79b/pydantic_evals-2.12.0.tar.gz", hash = "sha256:41b9937777fbfe38e350e45a10627a37b57bc48792de5061882f23a631f6e50a", size = 85044, upload-time = "2026-07-17T02:51:15.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/84/2e5219a022ff81356e6c7caecd137518fafa306a096f4ae9c9ba54f17bc2/pydantic_evals-2.19.0.tar.gz", hash = "sha256:d0908bbadada1761fab9d797e7e195b7633cbf13cc7beed1c224999260e9ed19", size = 85229, upload-time = "2026-07-28T03:40:52.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/97/f11605f7db4a363aee76523329f1caea7deafe384f660c88a33525baf499/pydantic_evals-2.12.0-py3-none-any.whl", hash = "sha256:43e32fe5ed9f8afa11bb8a722d64103a8f0156382e69fc2090ad2b0106a432b7", size = 100360, upload-time = "2026-07-17T02:51:08.759Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e1/d7eca8308ed48d53a739d71a93ee5fb398887bde2ddbeba9c0770bd4783e/pydantic_evals-2.19.0-py3-none-any.whl", hash = "sha256:d3962762a9a3cba29a6762845ad704a7ab2c93a25a7ed59a08c3ba5dea2e439a", size = 100525, upload-time = "2026-07-28T03:40:45.76Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "2.12.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1571,9 +1571,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/98/54070558cdd0245dfff239c8744a1d45e8cf195f00048e25a48e9d253b1b/pydantic_graph-2.12.0.tar.gz", hash = "sha256:b96e5448230fdac1cdfc3e1ca2a9c65d557a66427dc714b7fbd957319659f224", size = 43937, upload-time = "2026-07-17T02:51:16.134Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/7f/7ee83afef1f734fd736a43e66e4f0402d24e022fb3c07f83bd75ed8eb0da/pydantic_graph-2.19.0.tar.gz", hash = "sha256:2c14333a56c95649f4a18bea17ce043845d39bbb6c1f01c7cafec5eb24d4b66c", size = 44012, upload-time = "2026-07-28T03:40:53.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/53/c64d24b60b3ead0222c9cb722af86e51121132883bd51c506b54c6ee83df/pydantic_graph-2.12.0-py3-none-any.whl", hash = "sha256:dc2d7e149f7d7f1a3b29801df1781074e9f7b9e0d3cff5085c25369fc6590cce", size = 51653, upload-time = "2026-07-17T02:51:10.059Z" },
+    { url = "https://files.pythonhosted.org/packages/75/32/e81690f0110887b6c6fd579390f1baab8e489952e738df6e3a7fa2274cee/pydantic_graph-2.19.0-py3-none-any.whl", hash = "sha256:0fae00c8989e56922cd0315f5c576e39ba3cf2fc2e1a980002bd61aa3e0f5cbc", size = 51661, upload-time = "2026-07-28T03:40:47.218Z" },
 ]
 
 [[package]]
@@ -2027,8 +2027,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- lock the configured GitHub-backed just tool for Linux and macOS
- include the existing follow-up commits that supply the timing module referenced by master
- modernize type hints and imports required by the updated Ruff version
- preserve the dependency and CLI follow-up work already authored locally

## Validation

- locked mise install dry run
- Ruff check and format check
- Pyright: zero errors
- Pytest: 91 passed, 1 skipped

Fixes the failing mise setup and lint jobs on master.