### PR TITLE
ci: repair master workflow

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -76,5 +76,5 @@ jobs:
       - run: uv run ${{ github.event.repository.name }} output-prompt
       - run: uv run ${{ github.event.repository.name }} output-exclusions
       - run: uv run ${{ github.event.repository.name }} dump-prompts
-      - run: uv run ${{ github.event.repository.name }} install-pre-commit
+      - run: uv run ${{ github.event.repository.name }} install
       - run: just test

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This is the simplest way to add project-specific instructions without duplicatin
 To automatically generate commit messages during git commits:
 
 ```
-aiautocommit install-pre-commit
+aiautocommit install
 ```
 
 [Learn more about git hooks here.](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -123,7 +123,9 @@ EXCLUSIONS_FILE = "excluded_files.txt"
 COMMIT_SUFFIX_FILE = "commit_suffix.txt"
 
 # https://ai.pydantic.dev/models/overview
-MODEL_NAME = os.environ.get("AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview")
+MODEL_NAME = os.environ.get(
+    "AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview"
+)
 
 COMMIT_PROMPT = ""
 EXCLUDED_FILES = []

--- a/aiautocommit/internet.py
+++ b/aiautocommit/internet.py
@@ -20,5 +20,5 @@ def is_internet_connected():
         with socket.socket(socket.AF_INET) as s:
             s.connect(("google.com", 80))
             return True
-    except socket.error:
+    except OSError:
         return False

--- a/aiautocommit/log.py
+++ b/aiautocommit/log.py
@@ -1,9 +1,9 @@
-import os
 import logging
+import os
 import sys
 
-from structlog_config import configure_logger
 import structlog
+from structlog_config import configure_logger
 
 
 def setup_logging():

--- a/aiautocommit/pull_request.py
+++ b/aiautocommit/pull_request.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import time
 from pathlib import Path
-from typing import Optional
 
 from .log import log
 from .utils import is_default_branch, run_command
@@ -14,7 +13,7 @@ PR_CONTENT_CACHE_TTL = 7200  # 2 hours
 NEGATIVE_CACHE_TTL = 3600  # 1 hour
 
 
-def get_git_dir() -> Optional[Path]:
+def get_git_dir() -> Path | None:
     try:
         return Path(
             run_command(["git", "rev-parse", "--git-dir"], check=True).stdout.strip()
@@ -23,7 +22,7 @@ def get_git_dir() -> Optional[Path]:
         return None
 
 
-def get_pr_number_from_git_config(branch: str) -> Optional[str]:
+def get_pr_number_from_git_config(branch: str) -> str | None:
     """Check git config for a stored PR number."""
     try:
         result = run_command(
@@ -52,7 +51,7 @@ def get_pr_number_from_git_config(branch: str) -> Optional[str]:
     return None
 
 
-def get_pull_request_context(branch: str) -> Optional[str]:
+def get_pull_request_context(branch: str) -> str | None:
     """
     Fetch the pull request context for the given branch.
     Requires AIAUTOCOMMIT_INCLUDE_PR_CONTEXT environment variable to be truthy.

--- a/aiautocommit/timing.py
+++ b/aiautocommit/timing.py
@@ -1,0 +1,65 @@
+import functools
+from contextlib import ContextDecorator
+from time import perf_counter
+
+from .log import log
+
+
+class log_execution_time(ContextDecorator):
+    """
+    Context manager that logs the execution time of a block of code.
+
+    https://stackoverflow.com/questions/33987060/python-context-manager-that-measures-time
+
+    Usage:
+
+    with log_execution_time('description'):
+        # Your code here...
+    """
+
+    def __init__(self, msg=None):
+        """
+        :param msg: message to log, normally a function name
+        """
+
+        self.msg = msg
+
+    def __enter__(self):
+        self.time = perf_counter()
+        return self
+
+    # NOTE exit is still called even if an exception is raised
+    def __exit__(self, _type, _value, _traceback):
+        elapsed = perf_counter() - self.time
+
+        log.debug(
+            f"{self.msg} took {elapsed:.3f} seconds",
+            execution_time=elapsed,
+            function_name=self.msg,
+        )
+
+
+def log_time(msg=None):
+    """
+    Decorator that debug logs the execution time of a function.
+
+    >>> @log_time()
+    >>> def my_function():
+    >>>    pass
+
+    >>> @log_time('My custom message')
+    >>> def my_function():
+    >>>    pass
+    """
+
+    def decorator(func):
+        function_name = func.__name__
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with log_execution_time(msg or function_name):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/aiautocommit/utils.py
+++ b/aiautocommit/utils.py
@@ -1,6 +1,5 @@
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Union
 
 from .log import log
 from .timing import log_execution_time
@@ -38,13 +37,13 @@ def safe_git_diff_cmd() -> list[str]:
 
 
 def run_command(
-    args: List[str],
+    args: list[str],
     check: bool = False,
     capture_output: bool = True,
     text: bool = True,
-    timeout: Optional[float] = None,
-    env: Optional[dict[str, str]] = None,
-    cwd: Optional[Union[str, Path]] = None,
+    timeout: float | None = None,
+    env: dict[str, str] | None = None,
+    cwd: str | Path | None = None,
 ) -> subprocess.CompletedProcess:
     """
     Run a shell command using subprocess.run with logging.
@@ -79,7 +78,7 @@ def run_command(
             raise
 
 
-def get_current_branch() -> Optional[str]:
+def get_current_branch() -> str | None:
     """Get the name of the current git branch."""
     try:
         result = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True)

--- a/mise.lock
+++ b/mise.lock
@@ -4,12 +4,29 @@
 version = "2.37.1"
 backend = "asdf:direnv"
 
-[[tools.just]]
-version = "1.48.1"
-backend = "ubi:casey/just"
+[[tools."github:casey/just"]]
+version = "1.56.0"
+backend = "github:casey/just"
 
-[tools.just."platforms.macos-arm64-just"]
-checksum = "blake3:0deb700777be34ea81a1f743b4c014c32241d554a040296a0914604cea41ecf6"
+[tools."github:casey/just"."platforms.linux-arm64"]
+checksum = "sha256:c8c1d656e9f47569ec1ae2bf8779af2621cdeea6bbbba3b0cacd64f951d25e2b"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074960"
+
+[tools."github:casey/just"."platforms.linux-x64"]
+checksum = "sha256:fa2a8ec1015d9df5330941ade12437488fc40d33f9c9f8cd4eb70a26de11b639"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074624"
+
+[tools."github:casey/just"."platforms.macos-arm64"]
+checksum = "sha256:f35798d4bcdc4db020eef7d2853ad98bbfb97a4d29ee695ba042f18e7fedcc11"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074635"
+
+[tools."github:casey/just"."platforms.macos-x64"]
+checksum = "sha256:09b35ff6d17023ffae37ce408d1a78a976d9e001cae54b88e238f7f40db9b783"
+url = "https://github.com/casey/just/releases/download/1.56.0/just-1.56.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/472074650"
 
 [[tools.python]]
 version = "3.14.3"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 from tests.utils import GitTestMixin
@@ -19,6 +21,12 @@ def clean_env():
     # Restore environment
     os.environ.clear()
     os.environ.update(old_env)
+
+
+@pytest.fixture(autouse=True)
+def internet_connection_available():
+    with patch("aiautocommit.wait_for_internet_connection"):
+        yield
 
 
 @pytest.fixture

--- a/tests/test_ai_key.py
+++ b/tests/test_ai_key.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+
 from aiautocommit import update_env_variables
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from aiautocommit import check_lock_files, is_reversion, main, update_env_variables
+
 from tests.utils import GitTestMixin
 
 
@@ -195,8 +196,9 @@ def test_configure_prompts_with_examples(runner, git_repo):
 
 
 def test_complete_503_graceful_fallback():
-    from aiautocommit import complete
     from pydantic_ai.exceptions import ModelHTTPError
+
+    from aiautocommit import complete
 
     with patch("aiautocommit.Agent") as mock_agent_class:
         mock_agent = mock_agent_class.return_value

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -1,19 +1,22 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
+
 from aiautocommit import (
-    main,
-    is_reversion,
-    check_lock_files,
     LOCK_FILE_MESSAGES,
-    update_env_variables,
+    check_lock_files,
     configure_prompts,
+    get_diff_size,
+    is_reversion,
+    main,
+    sort_git_diff,
+    update_env_variables,
 )
 from aiautocommit.internet import wait_for_internet_connection
 from aiautocommit.utils import run_command
-from aiautocommit import sort_git_diff, get_diff_size
 
 
 def test_is_reversion_revert_head(git_repo):
@@ -93,7 +96,7 @@ def test_check_lock_files_not_mise_lock(git_repo):
 
 
 def test_get_diff_exclusion_glob(git_repo):
-    from aiautocommit import get_diff, configure_prompts
+    from aiautocommit import configure_prompts, get_diff
 
     # Setup a custom config with the glob pattern
     config_dir = Path("custom_config")
@@ -248,8 +251,8 @@ def test_generate_commit_message_with_suffix():
 
 
 def test_install_pre_commit_exists(runner, git_repo):
-    runner.invoke(main, ["install-pre-commit"])
-    result = runner.invoke(main, ["install-pre-commit"])
+    runner.invoke(main, ["install"])
+    result = runner.invoke(main, ["install"])
     assert "pre-commit hook already exists" in result.output
 
 
@@ -426,7 +429,7 @@ def test_main_default_invoke(runner):
     mock_ctx = MagicMock()
     mock_ctx.invoked_subcommand = None
     with patch("click.get_current_context", return_value=mock_ctx):
-        from aiautocommit import main, commit
+        from aiautocommit import commit, main
 
         main.callback()
         mock_ctx.invoke.assert_called_with(commit)

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,7 +1,9 @@
-from unittest.mock import patch, MagicMock
-from aiautocommit import complete
-from pydantic_ai.models.google import GoogleModel
+from unittest.mock import MagicMock, patch
+
 from google.genai.types import ThinkingLevel
+from pydantic_ai.models.google import GoogleModel
+
+from aiautocommit import complete
 
 
 @patch("aiautocommit.Agent")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,11 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 from click.testing import CliRunner
+
 from aiautocommit import main
+
 from tests.utils import GitTestMixin
 
 

--- a/tests/test_internet.py
+++ b/tests/test_internet.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
-import socket
+
 import pytest
+
 from aiautocommit.internet import is_internet_connected, wait_for_internet_connection
 
 
@@ -17,7 +18,7 @@ def test_is_internet_connected_success(mock_socket):
 def test_is_internet_connected_failure(mock_socket):
     # Mock connection failure
     instance = mock_socket.return_value.__enter__.return_value
-    instance.connect.side_effect = socket.error("no connection")
+    instance.connect.side_effect = OSError("no connection")
 
     assert is_internet_connected() is False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import subprocess
+
 import pytest
+
 from aiautocommit.utils import get_current_branch, run_command
 
 

--- a/tests/test_version_unknown.py
+++ b/tests/test_version_unknown.py
@@ -1,8 +1,8 @@
-import sys
 import os
-from unittest.mock import patch
+import sys
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from unittest.mock import patch
 
 
 def test_version_unknown():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
-import subprocess
 import os
+import subprocess
 
 
 class GitTestMixin:


### PR DESCRIPTION
## Summary

- lock the configured GitHub-backed just tool for Linux and macOS
- add the timing module already imported by master
- update stale install command references in CI, tests, and README
- apply mechanical Ruff import and type-hint fixes
- mock the network preflight in unit tests to remove external-network flakiness

## Validation

- locked mise install dry run
- Ruff check and format check
- Pyright: zero errors
- Pytest: 90 passed, 1 skipped

This excludes the unpublished dependency bump and unrelated commit-flow refactor from the superseded PR.