### PR TITLE
feat: update default model to google:gemini-3.5-flash-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Set your API key (works for any provider, Google Gemini is the default):
 
 ```shell
 export AIAUTOCOMMIT_AI_KEY=<YOUR API KEY>
+export AIAUTOCOMMIT_MODEL=google:gemini-3.5-flash-lite
 ```
 
 Stage your changes and run aiautocommit:
@@ -226,7 +227,7 @@ prepare-commit-msg:
 All environment variables used by `aiautocommit` or its providers can be prefixed with `AIAUTOCOMMIT_` to take precedence over the standard variable.
 
 * `AIAUTOCOMMIT_AI_KEY`: **Universal API key.** `aiautocommit` internally maps this to the correct provider-specific variable (e.g., `GOOGLE_API_KEY`, `OPENAI_API_KEY`) based on your active model.
-* `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `gemini:gemini-3-flash-preview`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
+* `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `google:gemini-3.5-flash-lite`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
 * `AIAUTOCOMMIT_CONFIG`: Custom config directory path
 * `AIAUTOCOMMIT_LOG_LEVEL`: Logging verbosity
 * `AIAUTOCOMMIT_LOG_PATH`: Custom log file path
@@ -241,10 +242,9 @@ Google Gemini models use "thinking" (Chain of Thought) with a minimal budget to 
 
 Common examples:
 
-* `gemini:gemini-3-flash-preview` (default)
+* `google:gemini-3.5-flash-lite` (default)
 * `openai:gpt-4o`
 * `anthropic:claude-3-5-sonnet-latest`
-* `gemini:gemini-1.5-pro`
 * `ollama:llama3` (for local models)
 
 Ensure you have the corresponding API key set in your environment (e.g., `ANTHROPIC_API_KEY` for Anthropic models).

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from .version import __version__
 
+DEFAULT_MODEL_NAME = "google:gemini-3.5-flash-lite"
+
 
 def map_ai_key(ai_key: str, model_name: str):
     """
@@ -55,9 +57,7 @@ def update_env_variables():
 
     # Handle universal AIAUTOCOMMIT_AI_KEY mapping
     if ai_key := os.environ.get("AIAUTOCOMMIT_AI_KEY"):
-        model_name = os.environ.get(
-            "AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview"
-        )
+        model_name = os.environ.get("AIAUTOCOMMIT_MODEL", DEFAULT_MODEL_NAME)
         map_ai_key(ai_key, model_name)
 
 
@@ -123,9 +123,7 @@ EXCLUSIONS_FILE = "excluded_files.txt"
 COMMIT_SUFFIX_FILE = "commit_suffix.txt"
 
 # https://ai.pydantic.dev/models/overview
-MODEL_NAME = os.environ.get(
-    "AIAUTOCOMMIT_MODEL", "google:gemini-3.1-flash-lite-preview"
-)
+MODEL_NAME = os.environ.get("AIAUTOCOMMIT_MODEL", DEFAULT_MODEL_NAME)
 
 COMMIT_PROMPT = ""
 EXCLUDED_FILES = []

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -8,6 +8,11 @@ def test_import() -> None:
     assert isinstance(aiautocommit.__name__, str)
 
 
+def test_default_model() -> None:
+    """Test that the default model is stable."""
+    assert aiautocommit.DEFAULT_MODEL_NAME == "google:gemini-3.5-flash-lite"
+
+
 def test_version() -> None:
     """Test that the version is available."""
     assert isinstance(aiautocommit.__version__, str)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from aiautocommit import main
+from aiautocommit import DEFAULT_MODEL_NAME, main
 
 from tests.utils import GitTestMixin
 
@@ -14,9 +14,7 @@ class TestIntegration(GitTestMixin):
     @pytest.fixture(autouse=True)
     def setup(self):
         self.runner = CliRunner()
-        self.model_name = os.environ.get(
-            "AIAUTOCOMMIT_MODEL", "gemini:gemini-flash-latest"
-        )
+        self.model_name = os.environ.get("AIAUTOCOMMIT_MODEL", DEFAULT_MODEL_NAME)
 
         # Verify we have an API key for integration tests
         if os.environ.get("OPENAI_API_KEY"):


### PR DESCRIPTION
## Summary

- set the application default to google:gemini-3.5-flash-lite
- use one shared default constant for model selection and API-key mapping
- update every concrete Gemini model reference in the README
- align the integration fallback and add a regression test

## Validation

- Ruff check and format check
- 8 focused tests passed
- reference inventory confirms the requested Google model is the only concrete Gemini model in README and application defaults