### PR TITLE
fix: type timing log messages

### DIFF
--- a/aiautocommit/timing.py
+++ b/aiautocommit/timing.py
@@ -17,7 +17,7 @@ class log_execution_time(ContextDecorator):
         # Your code here...
     """
 
-    def __init__(self, msg=None):
+    def __init__(self, msg: str):
         """
         :param msg: message to log, normally a function name
         """
@@ -39,7 +39,7 @@ class log_execution_time(ContextDecorator):
         )
 
 
-def log_time(msg=None):
+def log_time(msg: str | None = None):
     """
     Decorator that debug logs the execution time of a function.
 


### PR DESCRIPTION
Fix the current master Pyright failure by requiring string messages in the timing context manager and typing the optional decorator override.

Validation:
- Ruff check and format check
- Pyright: zero errors
- timing test passed