### PR TITLE
fix: use low thinking effort for Google Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Ensure you have the corresponding API key set in `AIAUTOCOMMIT_AI_KEY`.
 
 `aiautocommit` uses [pydantic-ai](https://ai.pydantic.dev/) under the hood, supporting a wide range of providers including OpenAI, Anthropic, and Gemini (via VertexAI or Generative AI) by default. You can specify the model using the `provider:model` syntax in the `AIAUTOCOMMIT_MODEL` environment variable.
 
-Google Gemini models use "thinking" (Chain of Thought) at the lowest budget the model supports (`minimal`, or `low` on Gemini 3.7+ where `minimal` is rejected).
+Google Gemini models use pydantic-ai's unified thinking setting at the lowest effort the model supports (`minimal`, or `low` on Gemini 3.7+ where `minimal` is rejected).
 
 Common examples:
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Ensure you have the corresponding API key set in `AIAUTOCOMMIT_AI_KEY`.
 
 `aiautocommit` uses [pydantic-ai](https://ai.pydantic.dev/) under the hood, supporting a wide range of providers including OpenAI, Anthropic, and Gemini (via VertexAI or Generative AI) by default. You can specify the model using the `provider:model` syntax in the `AIAUTOCOMMIT_MODEL` environment variable.
 
-Google Gemini models use pydantic-ai's unified thinking setting at the lowest effort the model supports (`minimal`, or `low` on Gemini 3.7+ where `minimal` is rejected).
+Google Gemini models use pydantic-ai's unified thinking setting at `low` effort. `minimal` is not used: newer Gemini models reject it.
 
 Common examples:
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ All environment variables used by `aiautocommit` or its providers can be prefixe
 
 * `AIAUTOCOMMIT_AI_KEY`: **Universal API key.** `aiautocommit` internally maps this to the correct provider-specific variable (e.g., `GOOGLE_API_KEY`, `OPENAI_API_KEY`) based on your active model.
 * `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `google:gemini-3.5-flash-lite`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
+* `AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`: Gemini thinking budget (`minimal`, `low`, `medium`, or `high`). Defaults to `minimal` for Gemini models through 3.5, and `low` for Gemini 3.7+ (which reject `minimal`).
 * `AIAUTOCOMMIT_CONFIG`: Custom config directory path
 * `AIAUTOCOMMIT_LOG_LEVEL`: Logging verbosity
 * `AIAUTOCOMMIT_LOG_PATH`: Custom log file path
@@ -238,7 +239,7 @@ Ensure you have the corresponding API key set in `AIAUTOCOMMIT_AI_KEY`.
 
 `aiautocommit` uses [pydantic-ai](https://ai.pydantic.dev/) under the hood, supporting a wide range of providers including OpenAI, Anthropic, and Gemini (via VertexAI or Generative AI) by default. You can specify the model using the `provider:model` syntax in the `AIAUTOCOMMIT_MODEL` environment variable.
 
-Google Gemini models use "thinking" (Chain of Thought) with a minimal budget to improve accuracy.
+Google Gemini models use "thinking" (Chain of Thought) to improve accuracy. The thinking budget defaults to `minimal` for models that support it, and `low` for Gemini 3.7+ (where `minimal` is rejected). Override with `AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`.
 
 Common examples:
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ All environment variables used by `aiautocommit` or its providers can be prefixe
 
 * `AIAUTOCOMMIT_AI_KEY`: **Universal API key.** `aiautocommit` internally maps this to the correct provider-specific variable (e.g., `GOOGLE_API_KEY`, `OPENAI_API_KEY`) based on your active model.
 * `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `google:gemini-3.5-flash-lite`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
-* `AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`: Gemini thinking budget (`minimal`, `low`, `medium`, or `high`). Defaults to `minimal` for Gemini models through 3.5, and `low` for Gemini 3.7+ (which reject `minimal`).
 * `AIAUTOCOMMIT_CONFIG`: Custom config directory path
 * `AIAUTOCOMMIT_LOG_LEVEL`: Logging verbosity
 * `AIAUTOCOMMIT_LOG_PATH`: Custom log file path
@@ -239,7 +238,7 @@ Ensure you have the corresponding API key set in `AIAUTOCOMMIT_AI_KEY`.
 
 `aiautocommit` uses [pydantic-ai](https://ai.pydantic.dev/) under the hood, supporting a wide range of providers including OpenAI, Anthropic, and Gemini (via VertexAI or Generative AI) by default. You can specify the model using the `provider:model` syntax in the `AIAUTOCOMMIT_MODEL` environment variable.
 
-Google Gemini models use "thinking" (Chain of Thought) to improve accuracy. The thinking budget defaults to `minimal` for models that support it, and `low` for Gemini 3.7+ (where `minimal` is rejected). Override with `AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`.
+Google Gemini models use "thinking" (Chain of Thought) at the lowest budget the model supports (`minimal`, or `low` on Gemini 3.7+ where `minimal` is rejected).
 
 Common examples:
 

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -314,6 +314,52 @@ class UserFacingError(click.ClickException):
         click.secho(self.format_message(), fg="red", err=True)
 
 
+# Gemini thinking_level values accepted by the API. Gemini 3.7+ rejects "minimal".
+GOOGLE_THINKING_LEVELS = ("minimal", "low", "medium", "high")
+
+
+def default_google_thinking_level(model_name: str) -> str:
+    """Pick a thinking level that the configured Gemini model accepts.
+
+    Gemini 3 models through 3.5 support ``minimal``. Gemini 3.7+ only supports
+    ``low`` / ``medium`` / ``high``; sending ``minimal`` returns an API error.
+    """
+    name = model_name.rsplit(":", 1)[-1].lower()
+    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name)
+    if not match:
+        return "minimal"
+
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    if (major, minor) >= (3, 7):
+        return "low"
+    return "minimal"
+
+
+def resolve_google_thinking_level(model_name: str):
+    """Return the Google ``ThinkingLevel`` for the active model.
+
+    Override with ``AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`` (or ``GOOGLE_THINKING_LEVEL``)
+    set to ``minimal``, ``low``, ``medium``, or ``high``.
+    """
+    from google.genai.types import ThinkingLevel
+
+    raw = os.environ.get("AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL") or os.environ.get(
+        "GOOGLE_THINKING_LEVEL"
+    )
+    if raw:
+        level = raw.strip().lower()
+        if level not in GOOGLE_THINKING_LEVELS:
+            allowed = ", ".join(GOOGLE_THINKING_LEVELS)
+            raise UserFacingError(
+                f"Invalid Google thinking level '{raw}'. Must be one of: {allowed}."
+            )
+    else:
+        level = default_google_thinking_level(model_name)
+
+    return ThinkingLevel[level.upper()]
+
+
 @log_execution_time("ai_generation")
 def complete(prompt, diff):
     if PROMPT_CUTOFF is not None and len(diff) > PROMPT_CUTOFF:
@@ -333,16 +379,15 @@ def complete(prompt, diff):
         from pydantic_ai.models.google import GoogleModel
 
         if isinstance(agent.model, GoogleModel):
-            # Configure minimal thinking budget for Gemini models
+            # Enable thinking (CoT) for Gemini; level depends on the model.
             # https://ai.pydantic.dev/models/google/#application-default-credentials
-            from google.genai.types import ThinkingLevel
             from pydantic_ai.models.google import GoogleModelSettings
 
             model_settings = GoogleModelSettings(
                 # include_thoughts=True improves accuracy via CoT and is filtered out of result.output by pydantic-ai
                 google_thinking_config={
                     "include_thoughts": True,
-                    "thinking_level": ThinkingLevel.MINIMAL,
+                    "thinking_level": resolve_google_thinking_level(MODEL_NAME),
                 }
             )
 

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -66,7 +66,7 @@ update_env_variables()
 from importlib.metadata import PackageNotFoundError, version  # noqa: E402
 
 import click  # noqa: E402
-from pydantic_ai import Agent  # noqa: E402
+from pydantic_ai import Agent, ModelSettings  # noqa: E402
 from pydantic_ai.exceptions import (  # noqa: E402
     ModelAPIError,
     ModelHTTPError,
@@ -329,14 +329,14 @@ def complete(prompt, diff):
         # Create the agent with the configured model
         agent = Agent(MODEL_NAME, system_prompt=prompt)
 
-        model_settings = None
+        model_settings: ModelSettings | None = None
         from pydantic_ai.models.google import GoogleModel
 
         if isinstance(agent.model, GoogleModel):
             # Gemini 3.7+ rejects thinking_level=minimal; low is the cheapest
             # level still accepted across current Gemini models.
             # https://ai.pydantic.dev/models/google/#configure-thinking
-            model_settings = {"thinking": "low"}
+            model_settings = ModelSettings(thinking="low")
 
         # Run the agent synchronously
         result = agent.run_sync(diff[:PROMPT_CUTOFF], model_settings=model_settings)

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -314,25 +314,6 @@ class UserFacingError(click.ClickException):
         click.secho(self.format_message(), fg="red", err=True)
 
 
-def lowest_thinking_effort(model_name: str) -> str:
-    """Cheapest pydantic-ai thinking effort the model will accept.
-
-    pydantic-ai's unified ``thinking`` setting maps ``minimal`` to Gemini
-    ``thinking_level=MINIMAL`` on all Gemini 3 models. Gemini 3.7+ rejects
-    that value, so those models get ``low``.
-    """
-    from pydantic_ai.models import parse_model_id
-
-    _, name = parse_model_id(model_name)
-    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name.lower())
-    if match:
-        major = int(match.group(1))
-        minor = int(match.group(2) or 0)
-        if (major, minor) >= (3, 7):
-            return "low"
-    return "minimal"
-
-
 @log_execution_time("ai_generation")
 def complete(prompt, diff):
     if PROMPT_CUTOFF is not None and len(diff) > PROMPT_CUTOFF:
@@ -352,11 +333,10 @@ def complete(prompt, diff):
         from pydantic_ai.models.google import GoogleModel
 
         if isinstance(agent.model, GoogleModel):
-            # Unified thinking maps to thinking_level (Gemini 3) or thinking_budget (2.5).
+            # Gemini 3.7+ rejects thinking_level=minimal; low is the cheapest
+            # level still accepted across current Gemini models.
             # https://ai.pydantic.dev/models/google/#configure-thinking
-            model_settings = {
-                "thinking": lowest_thinking_effort(agent.model.model_name),
-            }
+            model_settings = {"thinking": "low"}
 
         # Run the agent synchronously
         result = agent.run_sync(diff[:PROMPT_CUTOFF], model_settings=model_settings)

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -314,50 +314,22 @@ class UserFacingError(click.ClickException):
         click.secho(self.format_message(), fg="red", err=True)
 
 
-# Gemini thinking_level values accepted by the API. Gemini 3.7+ rejects "minimal".
-GOOGLE_THINKING_LEVELS = ("minimal", "low", "medium", "high")
+def google_thinking_level(model_name: str):
+    """Lowest ``thinking_level`` the configured Gemini model accepts.
 
-
-def default_google_thinking_level(model_name: str) -> str:
-    """Pick a thinking level that the configured Gemini model accepts.
-
-    Gemini 3 models through 3.5 support ``minimal``. Gemini 3.7+ only supports
-    ``low`` / ``medium`` / ``high``; sending ``minimal`` returns an API error.
-    """
-    name = model_name.rsplit(":", 1)[-1].lower()
-    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name)
-    if not match:
-        return "minimal"
-
-    major = int(match.group(1))
-    minor = int(match.group(2) or 0)
-    if (major, minor) >= (3, 7):
-        return "low"
-    return "minimal"
-
-
-def resolve_google_thinking_level(model_name: str):
-    """Return the Google ``ThinkingLevel`` for the active model.
-
-    Override with ``AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL`` (or ``GOOGLE_THINKING_LEVEL``)
-    set to ``minimal``, ``low``, ``medium``, or ``high``.
+    Gemini through 3.5 supports ``minimal``. Gemini 3.7+ rejects ``minimal``;
+    the lowest valid value is ``low``.
     """
     from google.genai.types import ThinkingLevel
 
-    raw = os.environ.get("AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL") or os.environ.get(
-        "GOOGLE_THINKING_LEVEL"
-    )
-    if raw:
-        level = raw.strip().lower()
-        if level not in GOOGLE_THINKING_LEVELS:
-            allowed = ", ".join(GOOGLE_THINKING_LEVELS)
-            raise UserFacingError(
-                f"Invalid Google thinking level '{raw}'. Must be one of: {allowed}."
-            )
-    else:
-        level = default_google_thinking_level(model_name)
-
-    return ThinkingLevel[level.upper()]
+    name = model_name.rsplit(":", 1)[-1].lower()
+    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name)
+    if match:
+        major = int(match.group(1))
+        minor = int(match.group(2) or 0)
+        if (major, minor) >= (3, 7):
+            return ThinkingLevel.LOW
+    return ThinkingLevel.MINIMAL
 
 
 @log_execution_time("ai_generation")
@@ -387,7 +359,7 @@ def complete(prompt, diff):
                 # include_thoughts=True improves accuracy via CoT and is filtered out of result.output by pydantic-ai
                 google_thinking_config={
                     "include_thoughts": True,
-                    "thinking_level": resolve_google_thinking_level(MODEL_NAME),
+                    "thinking_level": google_thinking_level(MODEL_NAME),
                 }
             )
 

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -314,22 +314,23 @@ class UserFacingError(click.ClickException):
         click.secho(self.format_message(), fg="red", err=True)
 
 
-def google_thinking_level(model_name: str):
-    """Lowest ``thinking_level`` the configured Gemini model accepts.
+def lowest_thinking_effort(model_name: str) -> str:
+    """Cheapest pydantic-ai thinking effort the model will accept.
 
-    Gemini through 3.5 supports ``minimal``. Gemini 3.7+ rejects ``minimal``;
-    the lowest valid value is ``low``.
+    pydantic-ai's unified ``thinking`` setting maps ``minimal`` to Gemini
+    ``thinking_level=MINIMAL`` on all Gemini 3 models. Gemini 3.7+ rejects
+    that value, so those models get ``low``.
     """
-    from google.genai.types import ThinkingLevel
+    from pydantic_ai.models import parse_model_id
 
-    name = model_name.rsplit(":", 1)[-1].lower()
-    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name)
+    _, name = parse_model_id(model_name)
+    match = re.search(r"gemini-(\d+)(?:\.(\d+))?", name.lower())
     if match:
         major = int(match.group(1))
         minor = int(match.group(2) or 0)
         if (major, minor) >= (3, 7):
-            return ThinkingLevel.LOW
-    return ThinkingLevel.MINIMAL
+            return "low"
+    return "minimal"
 
 
 @log_execution_time("ai_generation")
@@ -351,17 +352,11 @@ def complete(prompt, diff):
         from pydantic_ai.models.google import GoogleModel
 
         if isinstance(agent.model, GoogleModel):
-            # Enable thinking (CoT) for Gemini; level depends on the model.
-            # https://ai.pydantic.dev/models/google/#application-default-credentials
-            from pydantic_ai.models.google import GoogleModelSettings
-
-            model_settings = GoogleModelSettings(
-                # include_thoughts=True improves accuracy via CoT and is filtered out of result.output by pydantic-ai
-                google_thinking_config={
-                    "include_thoughts": True,
-                    "thinking_level": google_thinking_level(MODEL_NAME),
-                }
-            )
+            # Unified thinking maps to thinking_level (Gemini 3) or thinking_budget (2.5).
+            # https://ai.pydantic.dev/models/google/#configure-thinking
+            model_settings = {
+                "thinking": lowest_thinking_effort(agent.model.model_name),
+            }
 
         # Run the agent synchronously
         result = agent.run_sync(diff[:PROMPT_CUTOFF], model_settings=model_settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ dependencies = [
     "structlog-config>=0.6.0",
     "backoff>=2.2.1",
     "click>=8.1.7",
-    "pydantic-ai-slim[anthropic,google,openai]>=2.19.0",
+    "pydantic-ai-slim[anthropic,google,openai]>=2.29.0",
 ]
 authors = [{ name = "Michael Bianco", email = "mike@mikebian.co" }]
 urls = { "Repository" = "https://github.com/iloveitaly/aiautocommit" }
 
 [project.optional-dependencies]
 all-providers = [
-    "pydantic-ai>=2.19.0",
+    "pydantic-ai>=2.29.0",
 ]
 
 # additional packaging information: https://packaging.python.org/en/latest/specifications/core-metadata/#license

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,11 +1,36 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from google.genai.types import ThinkingLevel
 from pydantic_ai.models.google import GoogleModel
 
-from aiautocommit import complete
+from aiautocommit import (
+    UserFacingError,
+    complete,
+    default_google_thinking_level,
+    resolve_google_thinking_level,
+)
 
 
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("google:gemini-3.5-flash-lite", "minimal"),
+        ("google:gemini-3-flash", "minimal"),
+        ("google:gemini-2.5-flash", "minimal"),
+        ("google:gemini-3.7-flash", "low"),
+        ("gemini-3.7-flash", "low"),
+        ("google:gemini-3.7-pro", "low"),
+        ("google:gemini-4-flash", "low"),
+        ("google:gemini-3.8-flash", "low"),
+        ("openai:gpt-4o", "minimal"),
+    ],
+)
+def test_default_google_thinking_level(model_name, expected):
+    assert default_google_thinking_level(model_name) == expected
+
+
+@patch("aiautocommit.MODEL_NAME", "google:gemini-3.5-flash-lite")
 @patch("aiautocommit.Agent")
 def test_complete_gemini_thinking_config(MockAgent):
     mock_agent_instance = MockAgent.return_value
@@ -24,6 +49,45 @@ def test_complete_gemini_thinking_config(MockAgent):
         == ThinkingLevel.MINIMAL
     )
     assert model_settings["google_thinking_config"]["include_thoughts"] is True
+
+
+@patch("aiautocommit.MODEL_NAME", "google:gemini-3.7-flash")
+@patch("aiautocommit.Agent")
+def test_complete_gemini_37_uses_low_thinking(MockAgent):
+    mock_agent_instance = MockAgent.return_value
+    mock_agent_instance.model = MagicMock(spec=GoogleModel)
+    mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
+
+    complete("test prompt", "test diff")
+
+    args, kwargs = mock_agent_instance.run_sync.call_args
+    model_settings = kwargs["model_settings"]
+    assert (
+        model_settings["google_thinking_config"]["thinking_level"] == ThinkingLevel.LOW
+    )
+
+
+@patch.dict("os.environ", {"AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL": "high"})
+@patch("aiautocommit.MODEL_NAME", "google:gemini-3.7-flash")
+@patch("aiautocommit.Agent")
+def test_complete_gemini_thinking_level_override(MockAgent):
+    mock_agent_instance = MockAgent.return_value
+    mock_agent_instance.model = MagicMock(spec=GoogleModel)
+    mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
+
+    complete("test prompt", "test diff")
+
+    args, kwargs = mock_agent_instance.run_sync.call_args
+    model_settings = kwargs["model_settings"]
+    assert (
+        model_settings["google_thinking_config"]["thinking_level"] == ThinkingLevel.HIGH
+    )
+
+
+def test_resolve_google_thinking_level_invalid():
+    with patch.dict("os.environ", {"AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL": "extreme"}):
+        with pytest.raises(UserFacingError, match="Invalid Google thinking level"):
+            resolve_google_thinking_level("google:gemini-3.7-flash")
 
 
 @patch("aiautocommit.Agent")

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,48 +1,41 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from google.genai.types import ThinkingLevel
 from pydantic_ai.models.google import GoogleModel
 
-from aiautocommit import complete, google_thinking_level
+from aiautocommit import complete, lowest_thinking_effort
 
 
 @pytest.mark.parametrize(
     ("model_name", "expected"),
     [
-        ("google:gemini-3.5-flash-lite", ThinkingLevel.MINIMAL),
-        ("google:gemini-3-flash", ThinkingLevel.MINIMAL),
-        ("google:gemini-2.5-flash", ThinkingLevel.MINIMAL),
-        ("google:gemini-3.7-flash", ThinkingLevel.LOW),
-        ("gemini-3.7-flash", ThinkingLevel.LOW),
-        ("google:gemini-3.7-pro", ThinkingLevel.LOW),
-        ("google:gemini-4-flash", ThinkingLevel.LOW),
-        ("google:gemini-3.8-flash", ThinkingLevel.LOW),
+        ("google:gemini-3.5-flash-lite", "minimal"),
+        ("gemini-3.5-flash-lite", "minimal"),
+        ("google:gemini-3-flash", "minimal"),
+        ("google:gemini-2.5-flash", "minimal"),
+        ("google:gemini-3.7-flash", "low"),
+        ("gemini-3.7-flash", "low"),
+        ("google:gemini-3.7-pro", "low"),
+        ("google:gemini-4-flash", "low"),
+        ("google:gemini-3.8-flash", "low"),
     ],
 )
-def test_google_thinking_level(model_name, expected):
-    assert google_thinking_level(model_name) == expected
+def test_lowest_thinking_effort(model_name, expected):
+    assert lowest_thinking_effort(model_name) == expected
 
 
 @patch("aiautocommit.MODEL_NAME", "google:gemini-3.5-flash-lite")
 @patch("aiautocommit.Agent")
 def test_complete_gemini_thinking_config(MockAgent):
     mock_agent_instance = MockAgent.return_value
-    # Mock agent.model to be a GoogleModel instance
     mock_agent_instance.model = MagicMock(spec=GoogleModel)
+    mock_agent_instance.model.model_name = "gemini-3.5-flash-lite"
     mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
 
     complete("test prompt", "test diff")
 
-    # Verify that run_sync was called with model_settings
     args, kwargs = mock_agent_instance.run_sync.call_args
-    assert "model_settings" in kwargs
-    model_settings = kwargs["model_settings"]
-    assert (
-        model_settings["google_thinking_config"]["thinking_level"]
-        == ThinkingLevel.MINIMAL
-    )
-    assert model_settings["google_thinking_config"]["include_thoughts"] is True
+    assert kwargs["model_settings"]["thinking"] == "minimal"
 
 
 @patch("aiautocommit.MODEL_NAME", "google:gemini-3.7-flash")
@@ -50,21 +43,18 @@ def test_complete_gemini_thinking_config(MockAgent):
 def test_complete_gemini_37_uses_low_thinking(MockAgent):
     mock_agent_instance = MockAgent.return_value
     mock_agent_instance.model = MagicMock(spec=GoogleModel)
+    mock_agent_instance.model.model_name = "gemini-3.7-flash"
     mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
 
     complete("test prompt", "test diff")
 
     args, kwargs = mock_agent_instance.run_sync.call_args
-    model_settings = kwargs["model_settings"]
-    assert (
-        model_settings["google_thinking_config"]["thinking_level"] == ThinkingLevel.LOW
-    )
+    assert kwargs["model_settings"]["thinking"] == "low"
 
 
 @patch("aiautocommit.Agent")
 def test_complete_non_gemini_no_config(MockAgent):
     mock_agent_instance = MockAgent.return_value
-    # Mock agent.model to NOT be a GoogleModel instance
     mock_agent_instance.model = MagicMock()
     mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
 

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -1,49 +1,14 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pydantic_ai.models.google import GoogleModel
 
-from aiautocommit import complete, lowest_thinking_effort
+from aiautocommit import complete
 
 
-@pytest.mark.parametrize(
-    ("model_name", "expected"),
-    [
-        ("google:gemini-3.5-flash-lite", "minimal"),
-        ("gemini-3.5-flash-lite", "minimal"),
-        ("google:gemini-3-flash", "minimal"),
-        ("google:gemini-2.5-flash", "minimal"),
-        ("google:gemini-3.7-flash", "low"),
-        ("gemini-3.7-flash", "low"),
-        ("google:gemini-3.7-pro", "low"),
-        ("google:gemini-4-flash", "low"),
-        ("google:gemini-3.8-flash", "low"),
-    ],
-)
-def test_lowest_thinking_effort(model_name, expected):
-    assert lowest_thinking_effort(model_name) == expected
-
-
-@patch("aiautocommit.MODEL_NAME", "google:gemini-3.5-flash-lite")
 @patch("aiautocommit.Agent")
 def test_complete_gemini_thinking_config(MockAgent):
     mock_agent_instance = MockAgent.return_value
     mock_agent_instance.model = MagicMock(spec=GoogleModel)
-    mock_agent_instance.model.model_name = "gemini-3.5-flash-lite"
-    mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
-
-    complete("test prompt", "test diff")
-
-    args, kwargs = mock_agent_instance.run_sync.call_args
-    assert kwargs["model_settings"]["thinking"] == "minimal"
-
-
-@patch("aiautocommit.MODEL_NAME", "google:gemini-3.7-flash")
-@patch("aiautocommit.Agent")
-def test_complete_gemini_37_uses_low_thinking(MockAgent):
-    mock_agent_instance = MockAgent.return_value
-    mock_agent_instance.model = MagicMock(spec=GoogleModel)
-    mock_agent_instance.model.model_name = "gemini-3.7-flash"
     mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
 
     complete("test prompt", "test diff")

--- a/tests/test_gemini_config.py
+++ b/tests/test_gemini_config.py
@@ -4,30 +4,24 @@ import pytest
 from google.genai.types import ThinkingLevel
 from pydantic_ai.models.google import GoogleModel
 
-from aiautocommit import (
-    UserFacingError,
-    complete,
-    default_google_thinking_level,
-    resolve_google_thinking_level,
-)
+from aiautocommit import complete, google_thinking_level
 
 
 @pytest.mark.parametrize(
     ("model_name", "expected"),
     [
-        ("google:gemini-3.5-flash-lite", "minimal"),
-        ("google:gemini-3-flash", "minimal"),
-        ("google:gemini-2.5-flash", "minimal"),
-        ("google:gemini-3.7-flash", "low"),
-        ("gemini-3.7-flash", "low"),
-        ("google:gemini-3.7-pro", "low"),
-        ("google:gemini-4-flash", "low"),
-        ("google:gemini-3.8-flash", "low"),
-        ("openai:gpt-4o", "minimal"),
+        ("google:gemini-3.5-flash-lite", ThinkingLevel.MINIMAL),
+        ("google:gemini-3-flash", ThinkingLevel.MINIMAL),
+        ("google:gemini-2.5-flash", ThinkingLevel.MINIMAL),
+        ("google:gemini-3.7-flash", ThinkingLevel.LOW),
+        ("gemini-3.7-flash", ThinkingLevel.LOW),
+        ("google:gemini-3.7-pro", ThinkingLevel.LOW),
+        ("google:gemini-4-flash", ThinkingLevel.LOW),
+        ("google:gemini-3.8-flash", ThinkingLevel.LOW),
     ],
 )
-def test_default_google_thinking_level(model_name, expected):
-    assert default_google_thinking_level(model_name) == expected
+def test_google_thinking_level(model_name, expected):
+    assert google_thinking_level(model_name) == expected
 
 
 @patch("aiautocommit.MODEL_NAME", "google:gemini-3.5-flash-lite")
@@ -65,29 +59,6 @@ def test_complete_gemini_37_uses_low_thinking(MockAgent):
     assert (
         model_settings["google_thinking_config"]["thinking_level"] == ThinkingLevel.LOW
     )
-
-
-@patch.dict("os.environ", {"AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL": "high"})
-@patch("aiautocommit.MODEL_NAME", "google:gemini-3.7-flash")
-@patch("aiautocommit.Agent")
-def test_complete_gemini_thinking_level_override(MockAgent):
-    mock_agent_instance = MockAgent.return_value
-    mock_agent_instance.model = MagicMock(spec=GoogleModel)
-    mock_agent_instance.run_sync.return_value = MagicMock(output="test message")
-
-    complete("test prompt", "test diff")
-
-    args, kwargs = mock_agent_instance.run_sync.call_args
-    model_settings = kwargs["model_settings"]
-    assert (
-        model_settings["google_thinking_config"]["thinking_level"] == ThinkingLevel.HIGH
-    )
-
-
-def test_resolve_google_thinking_level_invalid():
-    with patch.dict("os.environ", {"AIAUTOCOMMIT_GOOGLE_THINKING_LEVEL": "extreme"}):
-        with pytest.raises(UserFacingError, match="Invalid Google thinking level"):
-            resolve_google_thinking_level("google:gemini-3.7-flash")
 
 
 @patch("aiautocommit.Agent")

--- a/uv.lock
+++ b/uv.lock
@@ -40,8 +40,8 @@ dev = [
 requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "click", specifier = ">=8.1.7" },
-    { name = "pydantic-ai", marker = "extra == 'all-providers'", specifier = ">=2.19.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=2.19.0" },
+    { name = "pydantic-ai", marker = "extra == 'all-providers'", specifier = ">=2.29.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=2.29.0" },
     { name = "structlog-config", specifier = ">=0.6.0" },
 ]
 provides-extras = ["all-providers"]
@@ -601,15 +601,15 @@ client = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.71"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/e1/203175825018a5dcdc5fde62afae57c0aa844ff1584d6c8d148107623f59/genai_prices-0.1.2.tar.gz", hash = "sha256:930ffd34e3b65e32d24818073a2fb65f0174c4de7f6afbebfee1efdf8b003877", size = 92403, upload-time = "2026-08-12T17:20:33.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/aa/54f2e6ed2699889fb5b062b1a6a58afa46f9fd0d095dc183e2173bd0b415/genai_prices-0.1.2-py3-none-any.whl", hash = "sha256:bdcdb9b358de01d9c3d4337a86b8dbfbf4e8044c2c064e6e3c4a6fef2f640382", size = 96579, upload-time = "2026-08-12T17:20:32.159Z" },
 ]
 
 [[package]]
@@ -1405,21 +1405,22 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "2.21.0"
+version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "retries", "web"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/42/85829a3e67bccdcb0335b59b41bdf0286277af5a33000314398fcfb8a492/pydantic_ai-2.21.0.tar.gz", hash = "sha256:6598c2f31c5275a8c00b523534a7e351a1146ecebfe58711a5d0615cc369f99f", size = 19005, upload-time = "2026-07-30T02:10:42.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ae/13bdac6a6117393f52278bba4210c944ff1ad8a0f0196f7f59939f02884c/pydantic_ai-2.29.0.tar.gz", hash = "sha256:4df3eceadc14e72a75631e15401b93693cf85c167ab1726881baa82ae61d94a2", size = 20287, upload-time = "2026-08-13T04:16:27.184Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/bd/042138f111f5bae9e4ea3b21c692092f8a63e7e3b35f9a69f153398dd4e2/pydantic_ai-2.21.0-py3-none-any.whl", hash = "sha256:a327f6d95b49d8003f6c19c38768e159e90a6a6930ddb81f4970313cb087765a", size = 7740, upload-time = "2026-07-30T02:10:34.505Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a4/9ad4c153b09ee5c19fc8b442c5ffdae79a2a4d47d1455a928cda294be0b9/pydantic_ai-2.29.0-py3-none-any.whl", hash = "sha256:46f17e73558e84ff178134cbf9dfc5f842b9ffe33efc993d70bfc0a2bdb4e484", size = 7935, upload-time = "2026-08-13T04:16:19.67Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.21.0"
+version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "genai-prices" },
     { name = "griffelib" },
     { name = "httpx" },
@@ -1428,9 +1429,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/c0/c699651a74cac2ac5e4bf19f568edf75fae529e456e2fee00ce94fe18f99/pydantic_ai_slim-2.21.0.tar.gz", hash = "sha256:dbcd6566ca1d05541f098aab42bb3464a1e39dfca6fe1af4d8e16f808e79a56c", size = 912884, upload-time = "2026-07-30T02:10:44.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/47/9ea38824b27efae7d19a34e2288697e0a84aa5cdd8c119ac85d030395ea3/pydantic_ai_slim-2.29.0.tar.gz", hash = "sha256:a5de25ebf8cf50187fe71be101e318e18e8ed469e5d8d1551d92b81ded1e3e99", size = 1197221, upload-time = "2026-08-13T04:16:29.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/01/05606613365f19d317eddbf5f2aaea0f947af9175c4ada5a4b577124583e/pydantic_ai_slim-2.21.0-py3-none-any.whl", hash = "sha256:25c34084808b944c000ad520553d8ac50c4d992972662a0e63f700009afb9bad", size = 1102191, upload-time = "2026-07-30T02:10:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/42/fda259cd11f88eb0ce7e54ee6a29011c0dd6a0af474403a2bb32d5dddb79/pydantic_ai_slim-2.29.0-py3-none-any.whl", hash = "sha256:cb5f5b7a941715b7f8894baae48ac178a603bdcf729726535964eaec25b07eb1", size = 1414034, upload-time = "2026-08-13T04:16:22.19Z" },
 ]
 
 [package.optional-dependencies]
@@ -1546,7 +1547,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "2.21.0"
+version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1556,24 +1557,25 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/36/9cdcd104240787c67b023a680c8f1a28c42317b37f3fc09c99c564eb307e/pydantic_evals-2.21.0.tar.gz", hash = "sha256:5c2dafa68c69f4660d6f422e688fcf3609af97c160c1e75fa4497fcbac97f74c", size = 85362, upload-time = "2026-07-30T02:10:45.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/b3/24878ef168e1fa653b02942e14f69d43702ff70f27d9fb5f503f01bcaf38/pydantic_evals-2.29.0.tar.gz", hash = "sha256:8fa3b504f58a4c4019f01c7d9e145fc352cd8363bc053e9c36deb1ccbde74932", size = 85871, upload-time = "2026-08-13T04:16:30.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/f8/9f095d2dcdb27707b6cb20741937b545e6742405fd7c90662c695b14ae9f/pydantic_evals-2.21.0-py3-none-any.whl", hash = "sha256:fb3d36c9abf9e675ec3606dcecd229573039f0de4be9829f6c66b1c59b7b93f7", size = 100528, upload-time = "2026-07-30T02:10:39.116Z" },
+    { url = "https://files.pythonhosted.org/packages/48/20/033c2564742c915ca31278c687ef012f3d5421a923b375eaec564c9139f0/pydantic_evals-2.29.0-py3-none-any.whl", hash = "sha256:806744e80616ab86da61ed617660d00defd6dd7dc6741407b344592a8e491ec0", size = 101086, upload-time = "2026-08-13T04:16:23.818Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "2.21.0"
+version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/d5/d3aa91f4e8dbae1bc863e02bce282b407f9499c6c40f92cada2be7ce5fc6/pydantic_graph-2.21.0.tar.gz", hash = "sha256:65b65134904cd13a7f153f042c41f65ee79cde1759e2f2291008976b18e73c38", size = 44150, upload-time = "2026-07-30T02:10:46.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/a4/364964ff4ca90fac651ffc969e04d75941389a39009fa2e950379bbcec93/pydantic_graph-2.29.0.tar.gz", hash = "sha256:078d2d7ab53ffb695e1a66c2a741880c88fef36611004736bf7313f8a5ec4465", size = 45180, upload-time = "2026-08-13T04:16:30.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/52/f9d1a615464b550a3335a754d8f554768acdbbaf4163093ef57e81da868b/pydantic_graph-2.21.0-py3-none-any.whl", hash = "sha256:28e68554a6b9df8c9b12cc337d492f4c00156a4d67f041a866af2913c73a2b99", size = 51661, upload-time = "2026-07-30T02:10:40.502Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d5/9a7e31a4895904c5d81989069630c47b7ef28d07256ae7ce1b8cda9964d1/pydantic_graph-2.29.0-py3-none-any.whl", hash = "sha256:afc81688c9abca9e93c4f7b81dd1112e8a7a8d4d41514413bd8d2c674bd2dfa1", size = 52661, upload-time = "2026-08-13T04:16:24.994Z" },
 ]
 
 [[package]]
@@ -2027,8 +2029,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Gemini 3.7 Flash rejects `thinking_level=minimal`. aiautocommit previously hardcoded `MINIMAL` for every Google model.

Rather than version-sniffing which models still accept `minimal`, Google models now always use pydantic-ai's unified `thinking='low'` — the cheapest level that current Gemini models accept as `minimal` is being phased out.

## Changes

- Bump `pydantic-ai-slim` / `pydantic-ai` to `>=2.29.0`
- For Google models, send `thinking: low` (no extra env var, no per-model branching)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7910f858-5a53-45b2-8666-9a1ff8aaf01b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7910f858-5a53-45b2-8666-9a1ff8aaf01b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

