### PR TITLE
feat: update default model to google:gemini-3.7-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Set your API key (works for any provider, Google Gemini is the default):
 
 ```shell
 export AIAUTOCOMMIT_AI_KEY=<YOUR API KEY>
-export AIAUTOCOMMIT_MODEL=google:gemini-3.5-flash-lite
+export AIAUTOCOMMIT_MODEL=google:gemini-3.7-flash
 ```
 
 Stage your changes and run aiautocommit:
@@ -227,7 +227,7 @@ prepare-commit-msg:
 All environment variables used by `aiautocommit` or its providers can be prefixed with `AIAUTOCOMMIT_` to take precedence over the standard variable.
 
 * `AIAUTOCOMMIT_AI_KEY`: **Universal API key.** `aiautocommit` internally maps this to the correct provider-specific variable (e.g., `GOOGLE_API_KEY`, `OPENAI_API_KEY`) based on your active model.
-* `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `google:gemini-3.5-flash-lite`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
+* `AIAUTOCOMMIT_MODEL`: AI model to use, in `provider:model` format (default: `google:gemini-3.7-flash`). Examples: `anthropic:claude-3-5-sonnet-latest`, `openai:gpt-4o`.
 * `AIAUTOCOMMIT_CONFIG`: Custom config directory path
 * `AIAUTOCOMMIT_LOG_LEVEL`: Logging verbosity
 * `AIAUTOCOMMIT_LOG_PATH`: Custom log file path
@@ -242,7 +242,7 @@ Google Gemini models use pydantic-ai's unified thinking setting at `low` effort.
 
 Common examples:
 
-* `google:gemini-3.5-flash-lite` (default)
+* `google:gemini-3.7-flash` (default)
 * `openai:gpt-4o`
 * `anthropic:claude-3-5-sonnet-latest`
 * `ollama:llama3` (for local models)

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .version import __version__
 
-DEFAULT_MODEL_NAME = "google:gemini-3.5-flash-lite"
+DEFAULT_MODEL_NAME = "google:gemini-3.7-flash"
 
 
 def map_ai_key(ai_key: str, model_name: str):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -10,7 +10,7 @@ def test_import() -> None:
 
 def test_default_model() -> None:
     """Test that the default model is stable."""
-    assert aiautocommit.DEFAULT_MODEL_NAME == "google:gemini-3.5-flash-lite"
+    assert aiautocommit.DEFAULT_MODEL_NAME == "google:gemini-3.7-flash"
 
 
 def test_version() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "aiautocommit"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump the default `AIAUTOCOMMIT_MODEL` from `google:gemini-3.5-flash-lite` to `google:gemini-3.7-flash`.

- Update `DEFAULT_MODEL_NAME` in `aiautocommit/__init__.py`
- Keep the import test locked to the new default
- Document the new default in the README

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8acd410c-0e16-4813-8f73-4d88da2732c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8acd410c-0e16-4813-8f73-4d88da2732c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

