### PR TITLE
feat(cli): include configured model in --version output

### DIFF
--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -514,8 +514,25 @@ def check_lock_files():
     return "chore(deps): update lock files" + COMMIT_SUFFIX
 
 
+def echo_cli_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+
+    prog_name = ctx.find_root().info_name or "aiautocommit"
+    click.echo(f"{prog_name}, version {get_cli_version()}")
+    click.echo(f"model: {MODEL_NAME}")
+    ctx.exit()
+
+
 @click.group(invoke_without_command=True)
-@click.version_option(version=get_cli_version())
+@click.option(
+    "--version",
+    is_flag=True,
+    expose_value=False,
+    is_eager=True,
+    callback=echo_cli_version,
+    help="Show the version and configured model and exit.",
+)
 def main():
     """
     Generate a commit message for staged files and commit them.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,16 +140,25 @@ def test_debug_prompt(runner, git_repo):
 
 
 def test_version_option(runner):
-    from aiautocommit import get_cli_version, is_local_source_checkout
+    from aiautocommit import MODEL_NAME, get_cli_version, is_local_source_checkout
 
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0
 
     cli_version = get_cli_version()
     assert cli_version in result.output
+    assert f"model: {MODEL_NAME}" in result.output
 
     if is_local_source_checkout():
         assert cli_version.endswith(".dev")
+
+
+def test_version_option_configured_model(runner):
+    with patch("aiautocommit.MODEL_NAME", "openai:gpt-4o"):
+        result = runner.invoke(main, ["--version"])
+
+    assert result.exit_code == 0
+    assert "model: openai:gpt-4o" in result.output
 
 
 def test_is_reversion_revert_head(runner, git_repo):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`--version` now prints the package version and the currently configured model (`AIAUTOCOMMIT_MODEL`, falling back to the default).

Example:

```
aiautocommit, version 0.24.0.dev
model: google:gemini-3.7-flash
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d628f3-6ba2-4815-a3c0-2b5432a7e49b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d628f3-6ba2-4815-a3c0-2b5432a7e49b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

