### PR TITLE
feat: structure commit prompt with XML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ aiautocommit dump-prompts
 Then add your scope specification to the commit prompt:
 
 ```
-#### 4. **Scopes**
-
+<scopes>
 Optional scopes (e.g., `feat(api):`):
 - `api`: API endpoints, controllers, services.
 - `frontend`: React components, styles, state management.
@@ -198,6 +197,7 @@ Optional scopes (e.g., `feat(api):`):
 - `jobs`: Background jobs, scheduled tasks.
 - `infra`: Infrastructure, networking, deployment, containerization.
 - `prompt`: Updates to LLM or AI prompts.
+</scopes>
 ```
 
 #### Lefthook Configuration

--- a/README.md
+++ b/README.md
@@ -140,21 +140,21 @@ If you create `.aiautocommit/examples/example_1.md`, `example_2.md`, and so on, 
 
 ```text
 <example>
-<context>
-- short|medium|large diff
-- include body: yes|no
-- primary change: one-line intent
-</context>
-
 <diff>
 diff --git ...
 </diff>
 
-<expected>
+<diffAnalysis>
+- short|medium|large diff
+- omit body | include body
+- primary change: one-line intent
+</diffAnalysis>
+
+<commitMessage>
 feat: concise subject
 
 - optional body bullet
-</expected>
+</commitMessage>
 </example>
 ```
 

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -354,16 +354,8 @@ def build_repo_information(branch: str, pr_context: str | None) -> str:
     return "\n".join(parts)
 
 
-def build_user_message(diff: str, repo_info: str | None = None) -> str:
-    truncated_diff = diff if PROMPT_CUTOFF is None else diff[:PROMPT_CUTOFF]
-    message = f"<diff>\n{truncated_diff}\n</diff>"
-    if repo_info:
-        return f"{repo_info}\n\n{message}"
-    return message
-
-
 @log_execution_time("ai_generation")
-def complete(prompt, diff, repo_info=None):
+def complete(prompt, diff):
     if PROMPT_CUTOFF is not None and len(diff) > PROMPT_CUTOFF:
         log.info(
             f"Prompt length ({len(diff)}) exceeds the maximum allowed length, truncating."
@@ -387,9 +379,7 @@ def complete(prompt, diff, repo_info=None):
             model_settings = ModelSettings(thinking="low")
 
         # Run the agent synchronously
-        result = agent.run_sync(
-            build_user_message(diff, repo_info), model_settings=model_settings
-        )
+        result = agent.run_sync(diff[:PROMPT_CUTOFF], model_settings=model_settings)
     except UserError as e:
         raise UserFacingError(e.message) from None
     except ModelHTTPError as e:
@@ -415,13 +405,15 @@ def generate_commit_message(diff):
         log.debug("No commit message generated")
         return ""
 
-    branch = get_current_branch()
     prompt = COMMIT_PROMPT
-    repo_info = None
+    branch = get_current_branch()
     if branch:
-        repo_info = build_repo_information(branch, get_pull_request_context(branch))
+        prompt = (
+            f"{prompt}\n\n"
+            f"{build_repo_information(branch, get_pull_request_context(branch))}"
+        )
 
-    message = complete(prompt, diff, repo_info=repo_info)
+    message = complete(prompt, diff)
     # If the generated message is empty, do not add the commit suffix.
     if not message.strip() or message.strip() == '""':
         return ""

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -226,7 +226,11 @@ def configure_prompts(config_dir=None):
     local_append_file = local_repo_config_path()
     if local_append_file.is_file():
         log.debug("found .aiautocommit file, appending to prompt")
-        COMMIT_PROMPT += "\n\n" + local_append_file.read_text().strip()
+        COMMIT_PROMPT += (
+            "\n\n<project_instructions>\n"
+            + local_append_file.read_text().strip()
+            + "\n</project_instructions>"
+        )
 
     examples_dir = config_dir / "examples"
     if examples_dir.exists():
@@ -342,8 +346,24 @@ class UserFacingError(click.ClickException):
         click.secho(self.format_message(), fg="red", err=True)
 
 
+def build_repo_information(branch: str, pr_context: str | None) -> str:
+    parts = ["<repo_information>", f"<branch>{branch}</branch>"]
+    if pr_context:
+        parts.append(pr_context.strip())
+    parts.append("</repo_information>")
+    return "\n".join(parts)
+
+
+def build_user_message(diff: str, repo_info: str | None = None) -> str:
+    truncated_diff = diff if PROMPT_CUTOFF is None else diff[:PROMPT_CUTOFF]
+    message = f"<diff>\n{truncated_diff}\n</diff>"
+    if repo_info:
+        return f"{repo_info}\n\n{message}"
+    return message
+
+
 @log_execution_time("ai_generation")
-def complete(prompt, diff):
+def complete(prompt, diff, repo_info=None):
     if PROMPT_CUTOFF is not None and len(diff) > PROMPT_CUTOFF:
         log.info(
             f"Prompt length ({len(diff)}) exceeds the maximum allowed length, truncating."
@@ -367,7 +387,9 @@ def complete(prompt, diff):
             model_settings = ModelSettings(thinking="low")
 
         # Run the agent synchronously
-        result = agent.run_sync(diff[:PROMPT_CUTOFF], model_settings=model_settings)
+        result = agent.run_sync(
+            build_user_message(diff, repo_info), model_settings=model_settings
+        )
     except UserError as e:
         raise UserFacingError(e.message) from None
     except ModelHTTPError as e:
@@ -395,21 +417,11 @@ def generate_commit_message(diff):
 
     branch = get_current_branch()
     prompt = COMMIT_PROMPT
+    repo_info = None
     if branch:
-        repo_info = f"<repo_information>\n- Current branch: {branch}\n"
+        repo_info = build_repo_information(branch, get_pull_request_context(branch))
 
-        pr_context = get_pull_request_context(branch)
-        if pr_context:
-            repo_info += f"\n{pr_context}\n"
-
-        repo_info += "</repo_information>"
-
-        if "<examples>" in prompt:
-            prompt = prompt.replace("<examples>", f"{repo_info}\n\n<examples>", 1)
-        else:
-            prompt = f"{prompt}\n\n{repo_info}"
-
-    message = complete(prompt, diff)
+    message = complete(prompt, diff, repo_info=repo_info)
     # If the generated message is empty, do not add the commit suffix.
     if not message.strip() or message.strip() == '""':
         return ""

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -242,11 +242,13 @@ def configure_prompts(config_dir=None):
         )
 
         if example_files:
-            COMMIT_PROMPT += "\n\n## Examples\n"
+            COMMIT_PROMPT += "\n\n<examples>\n"
 
-        for file in example_files:
-            log.debug(f"Adding example from {file}")
-            COMMIT_PROMPT += "\n\n" + file.read_text().strip() + "\n\n"
+            for file in example_files:
+                log.debug(f"Adding example from {file}")
+                COMMIT_PROMPT += "\n\n" + file.read_text().strip() + "\n\n"
+
+            COMMIT_PROMPT += "</examples>\n"
     else:
         log.debug(f"'examples' directory does not exist in {config_dir}")
 
@@ -394,14 +396,16 @@ def generate_commit_message(diff):
     branch = get_current_branch()
     prompt = COMMIT_PROMPT
     if branch:
-        repo_info = f"## Repo Information\n- Current branch: {branch}\n"
+        repo_info = f"<repo_information>\n- Current branch: {branch}\n"
 
         pr_context = get_pull_request_context(branch)
         if pr_context:
             repo_info += f"\n{pr_context}\n"
 
-        if "## Examples" in prompt:
-            prompt = prompt.replace("## Examples", f"{repo_info}\n## Examples")
+        repo_info += "</repo_information>"
+
+        if "<examples>" in prompt:
+            prompt = prompt.replace("<examples>", f"{repo_info}\n\n<examples>", 1)
         else:
             prompt = f"{prompt}\n\n{repo_info}"
 

--- a/aiautocommit/prompt/commit_prompt.txt
+++ b/aiautocommit/prompt/commit_prompt.txt
@@ -1,4 +1,3 @@
-<instructions>
 You are an expert software engineer. `git diff` output will be provided. Write a commit message using these rules:
 
 <subject_line>
@@ -33,4 +32,3 @@ You are an expert software engineer. `git diff` output will be provided. Write a
 <output>
 Return the commit message as plain text with no wrapping code fences or markdown formatting.
 </output>
-</instructions>

--- a/aiautocommit/prompt/commit_prompt.txt
+++ b/aiautocommit/prompt/commit_prompt.txt
@@ -1,9 +1,7 @@
-# Instructions
+<instructions>
+You are an expert software engineer. `git diff` output will be provided. Write a commit message using these rules:
 
-You are an expert software engineer. `git diff` output will be provided. Write a commit message  using these rules:
-
-## Subject Line
-
+<subject_line>
 - Use a conventional commit prefix:
   - `feat`: New features (visible to users).
   - `fix`: Bug fixes or corrections to existing (incorrect) behavior, including user-visible changes.
@@ -21,16 +19,18 @@ You are an expert software engineer. `git diff` output will be provided. Write a
   - "prevent text overflow" not "add break-all"
   - "validate email format" — "improve validation"
 - Do NOT reference filenames, line numbers, or tool names in the subject
+</subject_line>
 
-## Body (optional)
-
+<body>
 - Omit if the change is straightforward, self-explanatory, or can be easily understood from the subject.
 - Separate from subject with one blank line.
 - Use markdown bullets focusing on **why** the change was needed and **what impact** it has. No nested bullets.
 - Mention side effects, user impact, or important trade-offs.
 - If the diff contains unrelated changes, write the subject for the primary change and note secondary changes in the body.
 - Don't restate the diff in English — explain the reasoning behind it.
+</body>
 
-## Output
-
+<output>
 Return the commit message as plain text with no wrapping code fences or markdown formatting.
+</output>
+</instructions>

--- a/aiautocommit/prompt/commit_prompt.txt
+++ b/aiautocommit/prompt/commit_prompt.txt
@@ -30,5 +30,5 @@ You are an expert software engineer. `git diff` output will be provided. Write a
 </body>
 
 <output>
-Return the commit message as plain text with no wrapping code fences or markdown formatting.
+Return the commit message as plain text. Do not wrap it in XML tags, code fences, or other markdown.
 </output>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,8 @@ def test_configure_prompts_appends_file_from_subdirectory(runner, git_repo):
     from aiautocommit import COMMIT_PROMPT
 
     assert "Always mention JIRA tickets" in COMMIT_PROMPT
+    assert "<project_instructions>" in COMMIT_PROMPT
+    assert "</project_instructions>" in COMMIT_PROMPT
 
 
 def test_dump_prompts_to_git_root(runner, git_repo):
@@ -296,9 +298,32 @@ def test_complete_truncation():
         long_diff = "a" * (PROMPT_CUTOFF + 100)
         complete("prompt", long_diff)
 
-        # Verify run_sync was called with truncated diff
         call_args = mock_agent.run_sync.call_args[0][0]
-        assert len(call_args) == PROMPT_CUTOFF
+        assert call_args.startswith("<diff>\n")
+        assert call_args.endswith("\n</diff>")
+        inner_diff = call_args.removeprefix("<diff>\n").removesuffix("\n</diff>")
+        assert len(inner_diff) == PROMPT_CUTOFF
+
+
+def test_complete_wraps_diff_and_repo_information():
+    from aiautocommit import complete
+
+    with patch("aiautocommit.Agent") as mock_agent_class:
+        mock_agent = mock_agent_class.return_value
+        mock_agent.run_sync.return_value.output = "feat: test"
+
+        complete(
+            "prompt",
+            "the diff",
+            repo_info="<repo_information>\n<branch>main</branch>\n</repo_information>",
+        )
+
+        user_message = mock_agent.run_sync.call_args[0][0]
+
+    assert user_message.startswith("<repo_information>")
+    assert "<branch>main</branch>" in user_message
+    assert "<diff>\nthe diff\n</diff>" in user_message
+    assert user_message.index("</repo_information>") < user_message.index("<diff>")
 
 
 def test_configure_prompts_with_examples(runner, git_repo):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,32 +298,10 @@ def test_complete_truncation():
         long_diff = "a" * (PROMPT_CUTOFF + 100)
         complete("prompt", long_diff)
 
+        # Verify run_sync was called with the truncated raw diff as the user message
         call_args = mock_agent.run_sync.call_args[0][0]
-        assert call_args.startswith("<diff>\n")
-        assert call_args.endswith("\n</diff>")
-        inner_diff = call_args.removeprefix("<diff>\n").removesuffix("\n</diff>")
-        assert len(inner_diff) == PROMPT_CUTOFF
-
-
-def test_complete_wraps_diff_and_repo_information():
-    from aiautocommit import complete
-
-    with patch("aiautocommit.Agent") as mock_agent_class:
-        mock_agent = mock_agent_class.return_value
-        mock_agent.run_sync.return_value.output = "feat: test"
-
-        complete(
-            "prompt",
-            "the diff",
-            repo_info="<repo_information>\n<branch>main</branch>\n</repo_information>",
-        )
-
-        user_message = mock_agent.run_sync.call_args[0][0]
-
-    assert user_message.startswith("<repo_information>")
-    assert "<branch>main</branch>" in user_message
-    assert "<diff>\nthe diff\n</diff>" in user_message
-    assert user_message.index("</repo_information>") < user_message.index("<diff>")
+        assert call_args == long_diff[:PROMPT_CUTOFF]
+        assert "<diff>" not in call_args
 
 
 def test_configure_prompts_with_examples(runner, git_repo):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,11 +36,11 @@ def test_output_prompt(runner):
     result = runner.invoke(main, ["output-prompt"])
     assert result.exit_code == 0
     assert result.output.strip() != ""
-    assert "<instructions>" in result.output
     assert "<subject_line>" in result.output
     assert "<body>" in result.output
     assert "<output>" in result.output
     assert "<examples>" in result.output
+    assert "<instructions>" not in result.output
     assert "# Instructions" not in result.output
     assert "## Subject Line" not in result.output
     assert "## Examples" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,14 @@ def test_output_prompt(runner):
     result = runner.invoke(main, ["output-prompt"])
     assert result.exit_code == 0
     assert result.output.strip() != ""
+    assert "<instructions>" in result.output
+    assert "<subject_line>" in result.output
+    assert "<body>" in result.output
+    assert "<output>" in result.output
+    assert "<examples>" in result.output
+    assert "# Instructions" not in result.output
+    assert "## Subject Line" not in result.output
+    assert "## Examples" not in result.output
 
 
 def test_output_exclusions(runner):
@@ -310,6 +318,9 @@ def test_configure_prompts_with_examples(runner, git_repo):
     assert "base prompt" in COMMIT_PROMPT
     assert "example 1 content" in COMMIT_PROMPT
     assert "example 2 content" in COMMIT_PROMPT
+    assert COMMIT_PROMPT.index("<examples>") < COMMIT_PROMPT.index("example 1 content")
+    assert COMMIT_PROMPT.index("example 2 content") < COMMIT_PROMPT.index("</examples>")
+    assert "## Examples" not in COMMIT_PROMPT
 
 
 def test_complete_503_graceful_fallback():

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -258,8 +258,10 @@ def test_generate_commit_message_injects_xml_repo_information():
 
     captured = {}
 
-    def fake_complete(prompt, diff):
+    def fake_complete(prompt, diff, repo_info=None):
         captured["prompt"] = prompt
+        captured["diff"] = diff
+        captured["repo_info"] = repo_info
         return "feat: test"
 
     with (
@@ -274,13 +276,12 @@ def test_generate_commit_message_injects_xml_repo_information():
     ):
         generate_commit_message("some diff")
 
-    prompt = captured["prompt"]
-    assert "<repo_information>" in prompt
-    assert "</repo_information>" in prompt
-    assert "Current branch: feature/xml-tags" in prompt
-    assert prompt.index("<repo_information>") < prompt.index("<examples>")
-    assert "## Repo Information" not in prompt
-    assert "## Examples" not in prompt
+    assert captured["prompt"] == "base prompt\n\n<examples>\nexample\n</examples>"
+    assert captured["diff"] == "some diff"
+    assert "<repo_information>" in captured["repo_info"]
+    assert "<branch>feature/xml-tags</branch>" in captured["repo_info"]
+    assert "## Repo Information" not in captured["repo_info"]
+    assert "<repo_information>" not in captured["prompt"]
 
 
 def test_generate_commit_message_appends_repo_information_without_examples():
@@ -288,8 +289,9 @@ def test_generate_commit_message_appends_repo_information_without_examples():
 
     captured = {}
 
-    def fake_complete(prompt, diff):
+    def fake_complete(prompt, diff, repo_info=None):
         captured["prompt"] = prompt
+        captured["repo_info"] = repo_info
         return "feat: test"
 
     with (
@@ -304,16 +306,14 @@ def test_generate_commit_message_appends_repo_information_without_examples():
     ):
         generate_commit_message("some diff")
 
-    prompt = captured["prompt"]
-    assert prompt.startswith("base prompt only")
-    assert "<repo_information>" in prompt
-    assert "</repo_information>" in prompt
-    assert "Current branch: main" in prompt
-    assert "<pull_request_title>PR #1: title</pull_request_title>" in prompt
-    assert prompt.index("</repo_information>") > prompt.index(
+    assert captured["prompt"] == "base prompt only"
+    repo_info = captured["repo_info"]
+    assert "<branch>main</branch>" in repo_info
+    assert "<pull_request_title>PR #1: title</pull_request_title>" in repo_info
+    assert repo_info.index("</repo_information>") > repo_info.index(
         "<pull_request_title>PR #1: title</pull_request_title>"
     )
-    assert "## Repo Information" not in prompt
+    assert "## Repo Information" not in repo_info
 
 
 def test_install_pre_commit_exists(runner, git_repo):

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -283,6 +283,39 @@ def test_generate_commit_message_injects_xml_repo_information():
     assert "## Examples" not in prompt
 
 
+def test_generate_commit_message_appends_repo_information_without_examples():
+    from aiautocommit import generate_commit_message
+
+    captured = {}
+
+    def fake_complete(prompt, diff):
+        captured["prompt"] = prompt
+        return "feat: test"
+
+    with (
+        patch("aiautocommit.complete", side_effect=fake_complete),
+        patch("aiautocommit.get_current_branch", return_value="main"),
+        patch(
+            "aiautocommit.get_pull_request_context",
+            return_value="<pull_request_title>PR #1: title</pull_request_title>\n",
+        ),
+        patch("aiautocommit.COMMIT_PROMPT", "base prompt only"),
+        patch("aiautocommit.COMMIT_SUFFIX", ""),
+    ):
+        generate_commit_message("some diff")
+
+    prompt = captured["prompt"]
+    assert prompt.startswith("base prompt only")
+    assert "<repo_information>" in prompt
+    assert "</repo_information>" in prompt
+    assert "Current branch: main" in prompt
+    assert "<pull_request_title>PR #1: title</pull_request_title>" in prompt
+    assert prompt.index("</repo_information>") > prompt.index(
+        "<pull_request_title>PR #1: title</pull_request_title>"
+    )
+    assert "## Repo Information" not in prompt
+
+
 def test_install_pre_commit_exists(runner, git_repo):
     runner.invoke(main, ["install"])
     result = runner.invoke(main, ["install"])

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -258,10 +258,9 @@ def test_generate_commit_message_injects_xml_repo_information():
 
     captured = {}
 
-    def fake_complete(prompt, diff, repo_info=None):
+    def fake_complete(prompt, diff):
         captured["prompt"] = prompt
         captured["diff"] = diff
-        captured["repo_info"] = repo_info
         return "feat: test"
 
     with (
@@ -276,12 +275,13 @@ def test_generate_commit_message_injects_xml_repo_information():
     ):
         generate_commit_message("some diff")
 
-    assert captured["prompt"] == "base prompt\n\n<examples>\nexample\n</examples>"
+    prompt = captured["prompt"]
     assert captured["diff"] == "some diff"
-    assert "<repo_information>" in captured["repo_info"]
-    assert "<branch>feature/xml-tags</branch>" in captured["repo_info"]
-    assert "## Repo Information" not in captured["repo_info"]
-    assert "<repo_information>" not in captured["prompt"]
+    assert prompt.startswith("base prompt")
+    assert "<examples>" in prompt
+    assert prompt.index("</examples>") < prompt.index("<repo_information>")
+    assert "<branch>feature/xml-tags</branch>" in prompt
+    assert "## Repo Information" not in prompt
 
 
 def test_generate_commit_message_appends_repo_information_without_examples():
@@ -289,9 +289,9 @@ def test_generate_commit_message_appends_repo_information_without_examples():
 
     captured = {}
 
-    def fake_complete(prompt, diff, repo_info=None):
+    def fake_complete(prompt, diff):
         captured["prompt"] = prompt
-        captured["repo_info"] = repo_info
+        captured["diff"] = diff
         return "feat: test"
 
     with (
@@ -306,14 +306,15 @@ def test_generate_commit_message_appends_repo_information_without_examples():
     ):
         generate_commit_message("some diff")
 
-    assert captured["prompt"] == "base prompt only"
-    repo_info = captured["repo_info"]
-    assert "<branch>main</branch>" in repo_info
-    assert "<pull_request_title>PR #1: title</pull_request_title>" in repo_info
-    assert repo_info.index("</repo_information>") > repo_info.index(
+    prompt = captured["prompt"]
+    assert captured["diff"] == "some diff"
+    assert prompt.startswith("base prompt only")
+    assert "<branch>main</branch>" in prompt
+    assert "<pull_request_title>PR #1: title</pull_request_title>" in prompt
+    assert prompt.index("</repo_information>") > prompt.index(
         "<pull_request_title>PR #1: title</pull_request_title>"
     )
-    assert "## Repo Information" not in repo_info
+    assert "## Repo Information" not in prompt
 
 
 def test_install_pre_commit_exists(runner, git_repo):

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -172,6 +172,9 @@ def test_configure_prompts_examples(runner):
 
             assert "example 1 content" in aiautocommit.COMMIT_PROMPT
             assert "example 2 content" in aiautocommit.COMMIT_PROMPT
+            assert "<examples>" in aiautocommit.COMMIT_PROMPT
+            assert "</examples>" in aiautocommit.COMMIT_PROMPT
+            assert "## Examples" not in aiautocommit.COMMIT_PROMPT
 
 
 def test_wait_for_internet_connection_success():
@@ -248,6 +251,36 @@ def test_generate_commit_message_with_suffix():
     with patch("aiautocommit.complete", return_value="feat: test"):
         with patch("aiautocommit.COMMIT_SUFFIX", " [suffix]"):
             assert generate_commit_message("some diff") == "feat: test [suffix]"
+
+
+def test_generate_commit_message_injects_xml_repo_information():
+    from aiautocommit import generate_commit_message
+
+    captured = {}
+
+    def fake_complete(prompt, diff):
+        captured["prompt"] = prompt
+        return "feat: test"
+
+    with (
+        patch("aiautocommit.complete", side_effect=fake_complete),
+        patch("aiautocommit.get_current_branch", return_value="feature/xml-tags"),
+        patch("aiautocommit.get_pull_request_context", return_value=None),
+        patch(
+            "aiautocommit.COMMIT_PROMPT",
+            "base prompt\n\n<examples>\nexample\n</examples>",
+        ),
+        patch("aiautocommit.COMMIT_SUFFIX", ""),
+    ):
+        generate_commit_message("some diff")
+
+    prompt = captured["prompt"]
+    assert "<repo_information>" in prompt
+    assert "</repo_information>" in prompt
+    assert "Current branch: feature/xml-tags" in prompt
+    assert prompt.index("<repo_information>") < prompt.index("<examples>")
+    assert "## Repo Information" not in prompt
+    assert "## Examples" not in prompt
 
 
 def test_install_pre_commit_exists(runner, git_repo):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace markdown headers with XML tags for instruction sections, examples, and trusted repo metadata. The staged diff stays an untagged user message.

**System prompt**
- `## Subject Line` / `## Body` / `## Output` → `<subject_line>`, `<body>`, `<output>`
- No top-level `<instructions>` wrapper (this is already the system prompt)
- `.aiautocommit` file appends are wrapped in `<project_instructions>`
- Few-shot examples stay in `<examples>…</examples>`
- Branch/PR context is appended as `<repo_information>` with a `<branch>` child

**User message**
- The staged `git diff` is passed raw. It is not wrapped in `<diff>`: diffs often contain tag-like text (HTML, these example files), and the system/user role split is a stronger delimiter than in-band XML.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05798-6084-769c-81aa-4b0285e21245?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05798-6084-769c-81aa-4b0285e21245&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

