### PR TITLE
feat(cli): add global-ignores for home-level AI harness ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ aiautocommit output-exclusions
 
 # Generate a ChatGPT-ready debug block for a past commit to help iterate on the prompt
 aiautocommit debug-prompt <sha> "the commit message was too vague"
+
+# Ignore commands.md and instructions.md in home-level AI harness ignore files
+aiautocommit global-ignores --dry-run
+aiautocommit global-ignores
 ```
 
 `debug-prompt` outputs the diff, the generated commit message, and the full prompt in a format you can paste directly into ChatGPT to get suggestions for improving the prompt.

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -73,6 +73,7 @@ from pydantic_ai.exceptions import (  # noqa: E402
     UserError,
 )
 
+from .global_ignores import apply_global_ignores, format_ignore_plan  # noqa: E402
 from .internet import wait_for_internet_connection  # noqa: E402
 from .log import log  # noqa: E402
 from .pull_request import get_pull_request_context  # noqa: E402
@@ -747,6 +748,25 @@ def dump_prompts():
             shutil.copy(item, target)
 
     click.echo(f"Copied contents of {source_prompt_dir} to {config_dir}")
+
+
+@main.command("global-ignores")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="print planned home-level ignore updates without writing files",
+)
+def global_ignores(dry_run):
+    """
+    Ignore commands.md and instructions.md in home-level AI harness ignore files.
+
+    Writes gitignore-style patterns to ~/.cursorignore and the equivalent files
+    for other supported harnesses (Claude, Gemini, GitHub Copilot, OpenCode,
+    Antigravity, JetBrains, Windsurf).
+    """
+    planned = apply_global_ignores(dry_run=dry_run)
+    click.echo(format_ignore_plan(planned, dry_run=dry_run))
 
 
 @main.command()

--- a/aiautocommit/__init__.py
+++ b/aiautocommit/__init__.py
@@ -757,7 +757,7 @@ def dump_prompts():
     default=False,
     help="print planned home-level ignore updates without writing files",
 )
-def global_ignores(dry_run):
+def write_global_ignores(dry_run):
     """
     Ignore commands.md and instructions.md in home-level AI harness ignore files.
 

--- a/aiautocommit/global_ignores.py
+++ b/aiautocommit/global_ignores.py
@@ -1,0 +1,115 @@
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+GLOBAL_IGNORE_PATTERNS = ("commands.md", "instructions.md")
+
+# Home-level gitignore-style files used by AI coding harnesses.
+# `commands.md` / `instructions.md` with no slash match in any directory.
+HARNESS_IGNORE_FILES = {
+    "cursor": ".cursorignore",
+    "claude": ".claudeignore",
+    "gemini": ".geminiignore",
+    "github": ".copilotignore",
+    "opencode": ".opencodeignore",
+    "antigravity": ".aiexclude",
+    "jetbrains": ".aiignore",
+    "windsurf": ".codeiumignore",
+}
+
+START_MARKER = "# START AIAUTOCOMMIT GLOBAL IGNORES"
+END_MARKER = "# END AIAUTOCOMMIT GLOBAL IGNORES"
+
+
+class PlannedIgnoreWrite(NamedTuple):
+    harness: str
+    path: Path
+    action: str
+    new_content: str
+
+
+def home_dir() -> Path:
+    return Path.home()
+
+
+def ignore_block() -> str:
+    return "\n".join((START_MARKER, *GLOBAL_IGNORE_PATTERNS, END_MARKER))
+
+
+def upsert_ignore_content(existing: str) -> str:
+    block = ignore_block()
+
+    if START_MARKER in existing and END_MARKER in existing:
+        pattern = f"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}"
+        return re.sub(pattern, block, existing, count=1, flags=re.DOTALL)
+
+    content = existing
+    if content and not content.endswith("\n"):
+        content += "\n"
+
+    if content:
+        content += "\n"
+
+    return content + block + "\n"
+
+
+def plan_global_ignores(home: Path | None = None) -> list[PlannedIgnoreWrite]:
+    root = home if home is not None else home_dir()
+    planned: list[PlannedIgnoreWrite] = []
+
+    for harness, filename in HARNESS_IGNORE_FILES.items():
+        path = root / filename
+        existing = path.read_text() if path.exists() else ""
+        new_content = upsert_ignore_content(existing)
+
+        if not path.exists():
+            action = "create"
+        elif new_content == existing:
+            action = "unchanged"
+        else:
+            action = "update"
+
+        planned.append(
+            PlannedIgnoreWrite(
+                harness=harness,
+                path=path,
+                action=action,
+                new_content=new_content,
+            )
+        )
+
+    return planned
+
+
+def apply_global_ignores(
+    *, dry_run: bool = False, home: Path | None = None
+) -> list[PlannedIgnoreWrite]:
+    planned = plan_global_ignores(home)
+
+    if dry_run:
+        return planned
+
+    for item in planned:
+        if item.action == "unchanged":
+            continue
+
+        item.path.write_text(item.new_content)
+
+    return planned
+
+
+def format_ignore_plan(planned: list[PlannedIgnoreWrite], *, dry_run: bool) -> str:
+    verb = {
+        "create": "Would create" if dry_run else "Created",
+        "update": "Would update" if dry_run else "Updated",
+        "unchanged": "Unchanged",
+    }
+    patterns = ", ".join(GLOBAL_IGNORE_PATTERNS)
+    lines: list[str] = []
+
+    for item in planned:
+        lines.append(
+            f"{verb[item.action]} {item.path} ({item.harness}): {patterns}"
+        )
+
+    return "\n".join(lines)

--- a/tests/test_global_ignores.py
+++ b/tests/test_global_ignores.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from aiautocommit import main
+from aiautocommit.global_ignores import (
+    END_MARKER,
+    GLOBAL_IGNORE_PATTERNS,
+    HARNESS_IGNORE_FILES,
+    START_MARKER,
+    apply_global_ignores,
+    plan_global_ignores,
+    upsert_ignore_content,
+)
+
+
+def test_upsert_appends_marked_block():
+    result = upsert_ignore_content("node_modules/\n")
+
+    assert result.startswith("node_modules/\n")
+    assert START_MARKER in result
+    assert END_MARKER in result
+    for pattern in GLOBAL_IGNORE_PATTERNS:
+        assert pattern in result
+
+
+def test_upsert_replaces_existing_block():
+    existing = f"keep-me\n\n{START_MARKER}\nold.md\n{END_MARKER}\n\n*.log\n"
+
+    result = upsert_ignore_content(existing)
+
+    assert "keep-me" in result
+    assert "*.log" in result
+    assert "old.md" not in result
+    assert result.count(START_MARKER) == 1
+    assert result.count(END_MARKER) == 1
+    for pattern in GLOBAL_IGNORE_PATTERNS:
+        assert pattern in result
+
+
+def test_plan_creates_missing_home_files(tmp_path):
+    planned = plan_global_ignores(tmp_path)
+
+    assert {item.harness for item in planned} == set(HARNESS_IGNORE_FILES)
+    assert all(item.action == "create" for item in planned)
+    assert all(item.path.parent == tmp_path for item in planned)
+
+
+def test_apply_writes_all_harness_files(tmp_path):
+    planned = apply_global_ignores(home=tmp_path)
+
+    assert all(item.action == "create" for item in planned)
+    for filename in HARNESS_IGNORE_FILES.values():
+        content = (tmp_path / filename).read_text()
+        assert START_MARKER in content
+        assert "commands.md" in content
+        assert "instructions.md" in content
+
+
+def test_apply_is_idempotent(tmp_path):
+    apply_global_ignores(home=tmp_path)
+    planned = apply_global_ignores(home=tmp_path)
+
+    assert all(item.action == "unchanged" for item in planned)
+
+
+def test_apply_preserves_existing_ignore_rules(tmp_path):
+    cursorignore = tmp_path / ".cursorignore"
+    cursorignore.write_text("**/.env\n")
+
+    apply_global_ignores(home=tmp_path)
+
+    content = cursorignore.read_text()
+    assert content.startswith("**/.env\n")
+    assert "commands.md" in content
+    assert "instructions.md" in content
+
+
+def test_dry_run_does_not_write(tmp_path):
+    planned = apply_global_ignores(dry_run=True, home=tmp_path)
+
+    assert all(item.action == "create" for item in planned)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cli_dry_run(tmp_path, monkeypatch):
+    monkeypatch.setattr("aiautocommit.global_ignores.home_dir", lambda: tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["global-ignores", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Would create" in result.output
+    assert str(tmp_path / ".cursorignore") in result.output
+    assert "commands.md, instructions.md" in result.output
+    assert not (tmp_path / ".cursorignore").exists()
+
+
+def test_cli_writes_home_files(tmp_path, monkeypatch):
+    monkeypatch.setattr("aiautocommit.global_ignores.home_dir", lambda: tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["global-ignores"])
+
+    assert result.exit_code == 0
+    assert "Created" in result.output
+    assert (tmp_path / ".cursorignore").exists()
+    assert (tmp_path / ".claudeignore").exists()
+    assert (tmp_path / ".geminiignore").exists()
+    content = Path(tmp_path / ".cursorignore").read_text()
+    assert "commands.md" in content
+    assert "instructions.md" in content
+
+
+def test_cli_help_lists_command():
+    runner = CliRunner()
+    result = runner.invoke(main, ["global-ignores", "--help"])
+
+    assert result.exit_code == 0
+    assert "--dry-run" in result.output
+    assert "commands.md" in result.output

--- a/tests/test_global_ignores.py
+++ b/tests/test_global_ignores.py
@@ -15,7 +15,7 @@ from aiautocommit.global_ignores import (
 
 
 def test_upsert_appends_marked_block():
-    result = upsert_ignore_content("node_modules/\n")
+    result = upsert_ignore_content("node_modules/")
 
     assert result.startswith("node_modules/\n")
     assert START_MARKER in result
@@ -84,7 +84,9 @@ def test_dry_run_does_not_write(tmp_path):
 
 
 def test_cli_dry_run(tmp_path, monkeypatch):
-    monkeypatch.setattr("aiautocommit.global_ignores.home_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        "aiautocommit.global_ignores.home_dir", lambda: tmp_path
+    )
     runner = CliRunner()
 
     result = runner.invoke(main, ["global-ignores", "--dry-run"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `aiautocommit global-ignores` with `--dry-run`.

The command writes gitignore-style `commands.md` and `instructions.md` patterns into home-level ignore files for supported AI coding harnesses:

- `~/.cursorignore` (Cursor)
- `~/.claudeignore` (Claude)
- `~/.geminiignore` (Gemini)
- `~/.copilotignore` (GitHub Copilot)
- `~/.opencodeignore` (OpenCode)
- `~/.aiexclude` (Antigravity)
- `~/.aiignore` (JetBrains)
- `~/.codeiumignore` (Windsurf)

Patterns are wrapped in a replaceable marker block so re-runs are idempotent and do not clobber existing rules. `--dry-run` prints the planned creates/updates without writing files.

## Testing

- `pytest tests/test_global_ignores.py` (10 passed)
- Full unit suite: 117 passed, 1 skipped
- CLI demo with a temp `HOME`: dry-run leaves files untouched, apply writes the marker block, a second run reports unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8877ba18-9eca-4662-b3c1-8481fdcb66fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8877ba18-9eca-4662-b3c1-8481fdcb66fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

